### PR TITLE
com.openai.unity 2.2.3

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/AuthInfo.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/AuthInfo.cs
@@ -3,13 +3,14 @@
 using System;
 using System.Security.Authentication;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace OpenAI
 {
     [Serializable]
     internal class AuthInfo
     {
-        public AuthInfo(string apiKey, string organization = null)
+        public AuthInfo(string apiKey, string organizationId = null)
         {
             if (!apiKey.Contains("sk-"))
             {
@@ -18,14 +19,14 @@ namespace OpenAI
 
             this.apiKey = apiKey;
 
-            if (organization != null)
+            if (organizationId != null)
             {
-                if (!organization.Contains("org-"))
+                if (!organizationId.Contains("org-"))
                 {
-                    throw new InvalidCredentialException($"{nameof(organization)} must start with 'org-'");
+                    throw new InvalidCredentialException($"{nameof(organizationId)} must start with 'org-'");
                 }
 
-                this.organization = organization;
+                this.organizationId = organizationId;
             }
         }
 
@@ -35,8 +36,9 @@ namespace OpenAI
         public string ApiKey => apiKey;
 
         [SerializeField]
-        private string organization;
+        [FormerlySerializedAs("organization")]
+        private string organizationId;
 
-        public string Organization => organization;
+        public string OrganizationId => organizationId;
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/OpenAIAuthentication.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/OpenAIAuthentication.cs
@@ -16,6 +16,7 @@ namespace OpenAI
         private const string OPENAI_API_KEY = "OPENAI_API_KEY";
         private const string OPENAI_SECRET_KEY = "OPENAI_SECRET_KEY";
         private const string TEST_OPENAI_SECRET_KEY = "TEST_OPENAI_SECRET_KEY";
+        private const string OPEN_AI_ORGANIZATION_ID = "OPEN_AI_ORGANIZATION_ID";
         private const string ORGANIZATION = "ORGANIZATION";
 
         private readonly AuthInfo authInfo;
@@ -25,11 +26,14 @@ namespace OpenAI
         /// </summary>
         public string ApiKey => authInfo.ApiKey;
 
+        [Obsolete("Use OrganizationId instead")]
+        public string Organization => authInfo.OrganizationId;
+
         /// <summary>
         /// For users who belong to multiple organizations, you can pass a header to specify which organization is used for an API request.
         /// Usage from these API requests will count against the specified organization's subscription quota.
         /// </summary>
-        public string Organization => authInfo.Organization;
+        public string OrganizationId => authInfo.OrganizationId;
 
         /// <summary>
         /// Allows implicit casting from a string, so that a simple string API key can be provided in place of an instance of <see cref="OpenAIAuthentication"/>.
@@ -90,7 +94,7 @@ namespace OpenAI
         /// <summary>
         /// Attempts to load api keys from environment variables, as "OPENAI_KEY" (or "OPENAI_SECRET_KEY", for backwards compatibility)
         /// </summary>
-        /// <param name="organization">
+        /// <param name="organizationId">
         /// For users who belong to multiple organizations, you can pass a header to specify which organization is used for an API request.
         /// Usage from these API requests will count against the specified organization's subscription quota.
         /// </param>
@@ -98,7 +102,7 @@ namespace OpenAI
         /// Returns the loaded <see cref="OpenAIAuthentication"/> any api keys were found,
         /// or <see langword="null"/> if there were no matching environment vars.
         /// </returns>
-        public static OpenAIAuthentication LoadFromEnv(string organization = null)
+        public static OpenAIAuthentication LoadFromEnv(string organizationId = null)
         {
             var apiKey = Environment.GetEnvironmentVariable(OPENAI_KEY);
 
@@ -117,7 +121,12 @@ namespace OpenAI
                 apiKey = Environment.GetEnvironmentVariable(TEST_OPENAI_SECRET_KEY);
             }
 
-            return string.IsNullOrEmpty(apiKey) ? null : new OpenAIAuthentication(apiKey, organization);
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                organizationId = Environment.GetEnvironmentVariable(OPEN_AI_ORGANIZATION_ID);
+            }
+
+            return string.IsNullOrEmpty(apiKey) ? null : new OpenAIAuthentication(apiKey, organizationId);
         }
 
         /// <summary>

--- a/OpenAI/Packages/com.openai.unity/Runtime/OpenAIClient.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/OpenAIClient.cs
@@ -50,9 +50,9 @@ namespace OpenAI
             Client.DefaultRequestHeaders.Add("User-Agent", "com.openai.unity");
             Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", OpenAIAuthentication.ApiKey);
 
-            if (!string.IsNullOrWhiteSpace(OpenAIAuthentication.Organization))
+            if (!string.IsNullOrWhiteSpace(OpenAIAuthentication.OrganizationId))
             {
-                Client.DefaultRequestHeaders.Add("OpenAI-Organization", OpenAIAuthentication.Organization);
+                Client.DefaultRequestHeaders.Add("OpenAI-Organization", OpenAIAuthentication.OrganizationId);
             }
 
             Version = 1;

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_00_Authentication.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_00_Authentication.cs
@@ -30,8 +30,8 @@ namespace OpenAI.Tests
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.IsNotEmpty(auth.ApiKey);
-            Assert.IsNotNull(auth.Organization);
-            Assert.IsNotEmpty(auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.IsNotEmpty(auth.OrganizationId);
         }
 
         [Test]
@@ -41,8 +41,8 @@ namespace OpenAI.Tests
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.AreEqual("sk-test12", auth.ApiKey);
-            Assert.IsNotNull(auth.Organization);
-            Assert.AreEqual("org-testOrg", auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.AreEqual("org-testOrg", auth.OrganizationId);
         }
 
         [Test]
@@ -63,8 +63,8 @@ namespace OpenAI.Tests
             Assert.IsNotNull(auth);
             Assert.IsNotNull(auth.ApiKey);
             Assert.IsNotEmpty(auth.ApiKey);
-            Assert.IsNotNull(auth.Organization);
-            Assert.IsNotEmpty(auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.IsNotEmpty(auth.OrganizationId);
         }
 
         [Test]
@@ -76,18 +76,18 @@ namespace OpenAI.Tests
             var shouldBeDefaultAuth = api.OpenAIAuthentication;
             Assert.IsNotNull(shouldBeDefaultAuth);
             Assert.IsNotNull(shouldBeDefaultAuth.ApiKey);
-            Assert.IsNotNull(shouldBeDefaultAuth.Organization);
+            Assert.IsNotNull(shouldBeDefaultAuth.OrganizationId);
             Assert.AreEqual(defaultAuth.ApiKey, shouldBeDefaultAuth.ApiKey);
-            Assert.AreEqual(defaultAuth.Organization, shouldBeDefaultAuth.Organization);
+            Assert.AreEqual(defaultAuth.OrganizationId, shouldBeDefaultAuth.OrganizationId);
 
             OpenAIAuthentication.Default = new OpenAIAuthentication("sk-testAA", "org-testAA");
             api = new OpenAIClient();
             var shouldBeManualAuth = api.OpenAIAuthentication;
             Assert.IsNotNull(shouldBeManualAuth);
             Assert.IsNotNull(shouldBeManualAuth.ApiKey);
-            Assert.IsNotNull(shouldBeManualAuth.Organization);
+            Assert.IsNotNull(shouldBeManualAuth.OrganizationId);
             Assert.AreEqual(manualAuth.ApiKey, shouldBeManualAuth.ApiKey);
-            Assert.AreEqual(manualAuth.Organization, shouldBeManualAuth.Organization);
+            Assert.AreEqual(manualAuth.OrganizationId, shouldBeManualAuth.OrganizationId);
 
             OpenAIAuthentication.Default = defaultAuth;
         }
@@ -138,8 +138,8 @@ namespace OpenAI.Tests
         public void Test_09_GetOrganization()
         {
             var auth = new OpenAIAuthentication("sk-testAA", "org-testAA");
-            Assert.IsNotNull(auth.Organization);
-            Assert.AreEqual("org-testAA", auth.Organization);
+            Assert.IsNotNull(auth.OrganizationId);
+            Assert.AreEqual("org-testAA", auth.OrganizationId);
         }
 
         [Test]

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_07_FineTuning.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_07_FineTuning.cs
@@ -231,7 +231,7 @@ namespace OpenAI.Tests
 
                 foreach (var model in models)
                 {
-                    if (model.OwnedBy == api.OpenAIAuthentication.Organization)
+                    if (model.OwnedBy == api.OpenAIAuthentication.OrganizationId)
                     {
                         Debug.Log(model);
                         var result = await api.ModelsEndpoint.DeleteFineTuneModelAsync(model);

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "2.2.2",
+  "version": "2.2.3",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",


### PR DESCRIPTION
- #31 
- added `OPEN_AI_ORGANIZATION_ID` environment variable
- deprecated `Organization` use `OrganizationId` instead