### PR TITLE
com.openai.unity 2.2.4

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Documentation~/README.md
+++ b/OpenAI/Packages/com.openai.unity/Documentation~/README.md
@@ -88,13 +88,13 @@ There are 4 ways to provide your API keys, in order of precedence:
 #### Pass keys directly with constructor
 
 ```csharp
-var api = new OpenAIClient("sk-mykeyhere");
+var api = new OpenAIClient("sk-apiKey");
 ```
 
 Or create a `OpenAIAuthentication` object manually
 
 ```csharp
-var api = new OpenAIClient(new OpenAIAuthentication("sk-secretkey"));
+var api = new OpenAIClient(new OpenAIAuthentication("sk-apiKey", "org-yourOrganizationId"));
 ```
 
 #### Unity Scriptable Object
@@ -140,18 +140,11 @@ var api = new OpenAIClient(OpenAIAuthentication.LoadFromDirectory("your/path/to/
 Use your system's environment variables specify an api key and organization to use.
 
 - Use `OPENAI_API_KEY` for your api key.
-- Use `OPEN_AI_ORGANIZATION_ID` to specify an organization.
+- Use `OPENAI_ORGANIZATION_ID` to specify an organization.
 
 ```csharp
 var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
 ```
-
-or
-
-```csharp
-var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv("org-yourOrganizationId"));
-```
-
 
 ### [Models](https://beta.openai.com/docs/api-reference/models)
 
@@ -280,12 +273,12 @@ Creates an image given a prompt.
 var api = new OpenAIClient();
 var results = await api.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small);
 
-foreach (var result in results)
+foreach (var (path, texture) in results)
 {
-    Debug.Log(result.Key);
-    // result.Key == file://path/to/image.png
-    Assert.IsNotNull(result.Value);
-    // result.Value == The preloaded Texture2D
+    Debug.Log(path);
+    // path == file://path/to/image.png
+    Assert.IsNotNull(texture);
+    // texture == The preloaded Texture2D
 }
 ```
 
@@ -297,12 +290,12 @@ Creates an edited or extended image given an original image and a prompt.
 var api = new OpenAIClient();
 var results = await api.ImagesEndPoint.CreateImageEditAsync(Path.GetFullPath(imageAssetPath), Path.GetFullPath(maskAssetPath), "A sunlit indoor lounge area with a pool containing a flamingo", 1, ImageSize.Small);
 
-foreach (var result in results)
+foreach (var (path, texture) in results)
 {
-    Debug.Log(result.Key);
-    // result.Key == file://path/to/image.png
-    Assert.IsNotNull(result.Value);
-    // result.Value == Texture2D
+    Debug.Log(path);
+    // path == file://path/to/image.png
+    Assert.IsNotNull(texture);
+    // texture == The preloaded Texture2D
 }
 ```
 
@@ -314,12 +307,12 @@ Creates a variation of a given image.
 var api = new OpenAIClient();
 var results = await api.ImagesEndPoint.CreateImageVariationAsync(Path.GetFullPath(imageAssetPath), 1, ImageSize.Small);
 
-foreach (var result in results)
+foreach (var (path, texture) in results)
 {
-    Debug.Log(result.Key);
-    // result.Key == file://path/to/image.png
-    Assert.IsNotNull(result.Value);
-    // result.Value == Texture2D
+    Debug.Log(path);
+    // path == file://path/to/image.png
+    Assert.IsNotNull(texture);
+    // texture == The preloaded Texture2D
 }
 ```
 

--- a/OpenAI/Packages/com.openai.unity/Runtime/AuthInfo.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/AuthInfo.cs
@@ -12,14 +12,15 @@ namespace OpenAI
     {
         public AuthInfo(string apiKey, string organizationId = null)
         {
-            if (!apiKey.Contains("sk-"))
+            if (string.IsNullOrWhiteSpace(apiKey) ||
+                !apiKey.Contains("sk-"))
             {
                 throw new InvalidCredentialException($"{apiKey} must start with 'sk-'");
             }
 
             this.apiKey = apiKey;
 
-            if (organizationId != null)
+            if (!string.IsNullOrWhiteSpace(organizationId))
             {
                 if (!organizationId.Contains("org-"))
                 {

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageEditRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageEditRequest.cs
@@ -32,7 +32,15 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         public ImageEditRequest(string imagePath, string maskPath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            : this(File.OpenRead(imagePath), Path.GetFileName(imagePath), File.OpenRead(maskPath), Path.GetFileName(maskPath), prompt, numberOfResults, size, user)
+            : this(
+                File.OpenRead(imagePath),
+                Path.GetFileName(imagePath),
+                string.IsNullOrWhiteSpace(maskPath) ? null : File.OpenRead(maskPath),
+                string.IsNullOrWhiteSpace(maskPath) ? null : Path.GetFileName(maskPath),
+                prompt,
+                numberOfResults,
+                size,
+                user)
         {
         }
 
@@ -60,7 +68,15 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         public ImageEditRequest(Texture2D texture, Texture2D mask, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            : this(new MemoryStream(texture.EncodeToPNG()), $"{texture.name}.png", new MemoryStream(mask.EncodeToPNG()), $"{mask.name}.png", prompt, numberOfResults, size, user)
+            : this(
+                new MemoryStream(texture.EncodeToPNG()),
+                $"{texture.name}.png",
+                mask != null ? new MemoryStream(mask.EncodeToPNG()) : null,
+                mask != null ? $"{mask.name}.png" : null,
+                prompt,
+                numberOfResults,
+                size,
+                user)
         {
         }
 
@@ -99,14 +115,18 @@ namespace OpenAI.Images
             }
 
             ImageName = imageName;
-            Mask = mask;
 
-            if (string.IsNullOrWhiteSpace(maskName))
+            if (mask != null)
             {
-                maskName = "mask.png";
-            }
+                Mask = mask;
 
-            MaskName = maskName;
+                if (string.IsNullOrWhiteSpace(maskName))
+                {
+                    maskName = "mask.png";
+                }
+
+                MaskName = maskName;
+            }
 
             if (prompt.Length > 1000)
             {

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageVariationRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageVariationRequest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using UnityEngine;
 
 namespace OpenAI.Images
 {
@@ -12,7 +13,6 @@ namespace OpenAI.Images
         /// </summary>
         /// <param name="imagePath">
         /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
-        /// If mask is not provided, image must have transparency, which will be used as the mask.
         /// </param>
         /// <param name="numberOfResults">
         /// The number of images to generate. Must be between 1 and 10.
@@ -24,14 +24,58 @@ namespace OpenAI.Images
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         public ImageVariationRequest(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+            : this(File.OpenRead(imagePath), Path.GetFileName(imagePath), numberOfResults, size, user)
         {
-            if (!File.Exists(imagePath))
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="texture">
+        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        public ImageVariationRequest(Texture2D texture, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+            : this(new MemoryStream(texture.EncodeToPNG()), $"{texture.name}.png", numberOfResults, size, user)
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="image">
+        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// </param>
+        /// <param name="imageName">
+        /// The name of the image.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        public ImageVariationRequest(Stream image, string imageName, int numberOfResults, ImageSize size, string user)
+        {
+            Image = image;
+
+            if (string.IsNullOrWhiteSpace(imageName))
             {
-                throw new FileNotFoundException($"Could not find the {nameof(imagePath)} file located at {imagePath}");
+                imageName = "image.png";
             }
 
-            Image = File.OpenRead(imagePath);
-            ImageName = Path.GetFileName(imagePath);
+            ImageName = imageName;
 
             if (numberOfResults is > 10 or < 1)
             {

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
@@ -81,6 +81,33 @@ namespace OpenAI.Images
         /// <summary>
         /// Creates an edited or extended image given an original image and a prompt.
         /// </summary>
+        /// <param name="image">
+        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// If mask is not provided, image must have transparency, which will be used as the mask.
+        /// </param>
+        /// <param name="mask">
+        /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where image should be edited.
+        /// Must be a valid PNG file, less than 4MB, and have the same dimensions as image.
+        /// </param>
+        /// <param name="prompt">
+        /// A text description of the desired image(s). The maximum length is 1000 characters.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
+        /// <exception cref="HttpRequestException"></exception>
+        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageEditAsync(Texture2D image, Texture2D mask, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
+            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user), cancellationToken);
+
+        /// <summary>
+        /// Creates an edited or extended image given an original image and a prompt.
+        /// </summary>
         /// <param name="request"><see cref="ImageEditRequest"/></param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
@@ -129,6 +156,27 @@ namespace OpenAI.Images
         /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
         /// <exception cref="HttpRequestException"></exception>
         public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
+            => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user), cancellationToken);
+
+        /// <summary>
+        /// Creates a variation of a given image.
+        /// </summary>
+        /// <param name="imagePath">
+        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
+        /// <exception cref="HttpRequestException"></exception>
+        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(Texture2D imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
             => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user), cancellationToken);
 
         /// <summary>

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
@@ -118,9 +118,14 @@ namespace OpenAI.Images
             using var imageData = new MemoryStream();
             await request.Image.CopyToAsync(imageData, cancellationToken);
             content.Add(new ByteArrayContent(imageData.ToArray()), "image", request.ImageName);
-            using var maskData = new MemoryStream();
-            await request.Mask.CopyToAsync(maskData, cancellationToken);
-            content.Add(new ByteArrayContent(maskData.ToArray()), "mask", request.MaskName);
+
+            if (request.Mask != null)
+            {
+                using var maskData = new MemoryStream();
+                await request.Mask.CopyToAsync(maskData, cancellationToken);
+                content.Add(new ByteArrayContent(maskData.ToArray()), "mask", request.MaskName);
+            }
+
             content.Add(new StringContent(request.Prompt), "prompt");
             content.Add(new StringContent(request.Number.ToString()), "n");
             content.Add(new StringContent(request.Size), "size");
@@ -141,7 +146,6 @@ namespace OpenAI.Images
         /// </summary>
         /// <param name="imagePath">
         /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
-        /// If mask is not provided, image must have transparency, which will be used as the mask.
         /// </param>
         /// <param name="numberOfResults">
         /// The number of images to generate. Must be between 1 and 10.

--- a/OpenAI/Packages/com.openai.unity/Runtime/OpenAIAuthentication.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/OpenAIAuthentication.cs
@@ -16,6 +16,7 @@ namespace OpenAI
         private const string OPENAI_API_KEY = "OPENAI_API_KEY";
         private const string OPENAI_SECRET_KEY = "OPENAI_SECRET_KEY";
         private const string TEST_OPENAI_SECRET_KEY = "TEST_OPENAI_SECRET_KEY";
+        private const string OPENAI_ORGANIZATION_ID = "OPENAI_ORGANIZATION_ID";
         private const string OPEN_AI_ORGANIZATION_ID = "OPEN_AI_ORGANIZATION_ID";
         private const string ORGANIZATION = "ORGANIZATION";
 
@@ -124,6 +125,11 @@ namespace OpenAI
             if (string.IsNullOrWhiteSpace(organizationId))
             {
                 organizationId = Environment.GetEnvironmentVariable(OPEN_AI_ORGANIZATION_ID);
+            }
+
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                organizationId = Environment.GetEnvironmentVariable(OPENAI_ORGANIZATION_ID);
             }
 
             return string.IsNullOrEmpty(apiKey) ? null : new OpenAIAuthentication(apiKey, organizationId);

--- a/OpenAI/Packages/com.openai.unity/Tests/Images/image_edit_mask.png.meta
+++ b/OpenAI/Packages/com.openai.unity/Tests/Images/image_edit_mask.png.meta
@@ -20,7 +20,7 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
-  isReadable: 0
+  isReadable: 1
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
@@ -70,7 +70,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/OpenAI/Packages/com.openai.unity/Tests/Images/image_edit_original.png.meta
+++ b/OpenAI/Packages/com.openai.unity/Tests/Images/image_edit_original.png.meta
@@ -20,7 +20,7 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
-  isReadable: 0
+  isReadable: 1
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
@@ -70,7 +70,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_04_Images.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_04_Images.cs
@@ -34,7 +34,7 @@ namespace OpenAI.Tests
         }
 
         [UnityTest]
-        public IEnumerator Test_2_GenerateImageEdits()
+        public IEnumerator Test_2_CreateImageEdit_Path()
         {
             yield return AwaitTestUtilities.Await(async () =>
             {
@@ -56,7 +56,53 @@ namespace OpenAI.Tests
         }
 
         [UnityTest]
-        public IEnumerator Test_3_GenerateImageVariations()
+        public IEnumerator Test_3_CreateImageEdit_Texture()
+        {
+            yield return AwaitTestUtilities.Await(async () =>
+            {
+                var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+                Assert.IsNotNull(api.ImagesEndPoint);
+                var imageAssetPath = AssetDatabase.GUIDToAssetPath("230fd778637d3d84d81355c8c13b1999");
+                var image = AssetDatabase.LoadAssetAtPath<Texture2D>(imageAssetPath);
+                var maskAssetPath = AssetDatabase.GUIDToAssetPath("0be6be2fad590cc47930495d2ca37dd6");
+                var mask = AssetDatabase.LoadAssetAtPath<Texture2D>(maskAssetPath);
+                var results = await api.ImagesEndPoint.CreateImageEditAsync(image, mask, "A sunlit indoor lounge area with a pool containing a flamingo", 1, ImageSize.Small);
+
+                Assert.IsNotNull(results);
+                Assert.NotZero(results.Count);
+
+                foreach (var result in results)
+                {
+                    Debug.Log(result.Key);
+                    Assert.IsNotNull(result.Value);
+                }
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Test_4_CreateImageEdit_MaskAsTransparency()
+        {
+            yield return AwaitTestUtilities.Await(async () =>
+            {
+                var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+                Assert.IsNotNull(api.ImagesEndPoint);
+                var maskAssetPath = AssetDatabase.GUIDToAssetPath("0be6be2fad590cc47930495d2ca37dd6");
+                var mask = AssetDatabase.LoadAssetAtPath<Texture2D>(maskAssetPath);
+                var results = await api.ImagesEndPoint.CreateImageEditAsync(mask, null, "A sunlit indoor lounge area with a pool containing a flamingo", 1, ImageSize.Small);
+
+                Assert.IsNotNull(results);
+                Assert.NotZero(results.Count);
+
+                foreach (var result in results)
+                {
+                    Debug.Log(result.Key);
+                    Assert.IsNotNull(result.Value);
+                }
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Test_5_CreateImageVariation_Path()
         {
             yield return AwaitTestUtilities.Await(async () =>
             {
@@ -64,6 +110,28 @@ namespace OpenAI.Tests
                 Assert.IsNotNull(api.ImagesEndPoint);
                 var imageAssetPath = AssetDatabase.GUIDToAssetPath("230fd778637d3d84d81355c8c13b1999");
                 var results = await api.ImagesEndPoint.CreateImageVariationAsync(Path.GetFullPath(imageAssetPath), 1, ImageSize.Small);
+
+                Assert.IsNotNull(results);
+                Assert.NotZero(results.Count);
+
+                foreach (var result in results)
+                {
+                    Debug.Log(result.Key);
+                    Assert.IsNotNull(result.Value);
+                }
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Test_6_CreateImageVariation_Texture()
+        {
+            yield return AwaitTestUtilities.Await(async () =>
+            {
+                var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+                Assert.IsNotNull(api.ImagesEndPoint);
+                var imageAssetPath = AssetDatabase.GUIDToAssetPath("230fd778637d3d84d81355c8c13b1999");
+                var image = AssetDatabase.LoadAssetAtPath<Texture2D>(imageAssetPath);
+                var results = await api.ImagesEndPoint.CreateImageVariationAsync(image, 1, ImageSize.Small);
 
                 Assert.IsNotNull(results);
                 Assert.NotZero(results.Count);

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_04_Images.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_04_Images.cs
@@ -25,10 +25,10 @@ namespace OpenAI.Tests
                 Assert.IsNotNull(results);
                 Assert.NotZero(results.Count);
 
-                foreach (var result in results)
+                foreach (var (path, texture) in results)
                 {
-                    Debug.Log(result.Key);
-                    Assert.IsNotNull(result.Value);
+                    Debug.Log(path);
+                    Assert.IsNotNull(texture);
                 }
             });
         }
@@ -47,10 +47,10 @@ namespace OpenAI.Tests
                 Assert.IsNotNull(results);
                 Assert.NotZero(results.Count);
 
-                foreach (var result in results)
+                foreach (var (path, texture) in results)
                 {
-                    Debug.Log(result.Key);
-                    Assert.IsNotNull(result.Value);
+                    Debug.Log(path);
+                    Assert.IsNotNull(texture);
                 }
             });
         }
@@ -71,10 +71,10 @@ namespace OpenAI.Tests
                 Assert.IsNotNull(results);
                 Assert.NotZero(results.Count);
 
-                foreach (var result in results)
+                foreach (var (path, texture) in results)
                 {
-                    Debug.Log(result.Key);
-                    Assert.IsNotNull(result.Value);
+                    Debug.Log(path);
+                    Assert.IsNotNull(texture);
                 }
             });
         }
@@ -93,10 +93,10 @@ namespace OpenAI.Tests
                 Assert.IsNotNull(results);
                 Assert.NotZero(results.Count);
 
-                foreach (var result in results)
+                foreach (var (path, texture) in results)
                 {
-                    Debug.Log(result.Key);
-                    Assert.IsNotNull(result.Value);
+                    Debug.Log(path);
+                    Assert.IsNotNull(texture);
                 }
             });
         }
@@ -114,10 +114,10 @@ namespace OpenAI.Tests
                 Assert.IsNotNull(results);
                 Assert.NotZero(results.Count);
 
-                foreach (var result in results)
+                foreach (var (path, texture) in results)
                 {
-                    Debug.Log(result.Key);
-                    Assert.IsNotNull(result.Value);
+                    Debug.Log(path);
+                    Assert.IsNotNull(texture);
                 }
             });
         }
@@ -136,10 +136,10 @@ namespace OpenAI.Tests
                 Assert.IsNotNull(results);
                 Assert.NotZero(results.Count);
 
-                foreach (var result in results)
+                foreach (var (path, texture) in results)
                 {
-                    Debug.Log(result.Key);
-                    Assert.IsNotNull(result.Value);
+                    Debug.Log(path);
+                    Assert.IsNotNull(texture);
                 }
             });
         }

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "2.2.3",
+  "version": "2.2.4",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.0.2",
-    "com.utilities.rest": "1.1.0"
+    "com.utilities.rest": "1.2.0"
   },
   "publishConfig": {
     "registry": "https://package.openupm.com"

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.0.2",
-    "com.utilities.rest": "1.2.1"
+    "com.utilities.rest": "1.2.2"
   },
   "publishConfig": {
     "registry": "https://package.openupm.com"

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.0.2",
-    "com.utilities.rest": "1.2.0"
+    "com.utilities.rest": "1.2.1"
   },
   "publishConfig": {
     "registry": "https://package.openupm.com"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The recommended installation method is though the unity package manager and [Ope
     - `com.openai`
     - `com.utilities`
 
-![scoped-registries](https://github.com/RageAgainstThePixel/com.openai.unity/raw/main/OpenAI/Packages/com.openai.unity/Documentation~/images/package-manager-scopes.png)
+![scoped-registries](OpenAI/Packages/com.openai.unity/Documentation~/images/package-manager-scopes.png)
 
 - Open the Unity Package Manager window
 - Change the Registry from Unity to `My Registries`
@@ -88,13 +88,13 @@ There are 4 ways to provide your API keys, in order of precedence:
 #### Pass keys directly with constructor
 
 ```csharp
-var api = new OpenAIClient("sk-mykeyhere");
+var api = new OpenAIClient("sk-apiKey");
 ```
 
 Or create a `OpenAIAuthentication` object manually
 
 ```csharp
-var api = new OpenAIClient(new OpenAIAuthentication("sk-secretkey"));
+var api = new OpenAIClient(new OpenAIAuthentication("sk-apiKey", "org-yourOrganizationId"));
 ```
 
 #### Unity Scriptable Object
@@ -103,7 +103,7 @@ You can save the key directly into a scriptable object that is located in the `A
 
 You can create a new one by using the context menu of the project pane and creating a new `OpenAIConfigurationSettings` scriptable object.
 
-![Create new OpenAIConfigurationSettings](https://github.com/RageAgainstThePixel/com.openai.unity/raw/main/OpenAI/Packages/com.openai.unity/Documentation~/images/create-scriptable-object.png)
+![Create new OpenAIConfigurationSettings](images/create-scriptable-object.png)
 
 #### Load key from configuration file
 
@@ -140,18 +140,11 @@ var api = new OpenAIClient(OpenAIAuthentication.LoadFromDirectory("your/path/to/
 Use your system's environment variables specify an api key and organization to use.
 
 - Use `OPENAI_API_KEY` for your api key.
-- Use `OPEN_AI_ORGANIZATION_ID` to specify an organization.
+- Use `OPENAI_ORGANIZATION_ID` to specify an organization.
 
 ```csharp
 var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
 ```
-
-or
-
-```csharp
-var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv("org-yourOrganizationId"));
-```
-
 
 ### [Models](https://beta.openai.com/docs/api-reference/models)
 
@@ -280,12 +273,12 @@ Creates an image given a prompt.
 var api = new OpenAIClient();
 var results = await api.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small);
 
-foreach (var result in results)
+foreach (var (path, texture) in results)
 {
-    Debug.Log(result.Key);
-    // result.Key == file://path/to/image.png
-    Assert.IsNotNull(result.Value);
-    // result.Value == The preloaded Texture2D
+    Debug.Log(path);
+    // path == file://path/to/image.png
+    Assert.IsNotNull(texture);
+    // texture == The preloaded Texture2D
 }
 ```
 
@@ -297,12 +290,12 @@ Creates an edited or extended image given an original image and a prompt.
 var api = new OpenAIClient();
 var results = await api.ImagesEndPoint.CreateImageEditAsync(Path.GetFullPath(imageAssetPath), Path.GetFullPath(maskAssetPath), "A sunlit indoor lounge area with a pool containing a flamingo", 1, ImageSize.Small);
 
-foreach (var result in results)
+foreach (var (path, texture) in results)
 {
-    Debug.Log(result.Key);
-    // result.Key == file://path/to/image.png
-    Assert.IsNotNull(result.Value);
-    // result.Value == Texture2D
+    Debug.Log(path);
+    // path == file://path/to/image.png
+    Assert.IsNotNull(texture);
+    // texture == The preloaded Texture2D
 }
 ```
 
@@ -314,12 +307,12 @@ Creates a variation of a given image.
 var api = new OpenAIClient();
 var results = await api.ImagesEndPoint.CreateImageVariationAsync(Path.GetFullPath(imageAssetPath), 1, ImageSize.Small);
 
-foreach (var result in results)
+foreach (var (path, texture) in results)
 {
-    Debug.Log(result.Key);
-    // result.Key == file://path/to/image.png
-    Assert.IsNotNull(result.Value);
-    // result.Value == Texture2D
+    Debug.Log(path);
+    // path == file://path/to/image.png
+    Assert.IsNotNull(texture);
+    // texture == The preloaded Texture2D
 }
 ```
 


### PR DESCRIPTION
- support native texture image variations and edits
  - texture's require the following import settings:
    - no compression
    - read/write enabled 
- made image edit mask optional as long as main texture has transparency
- updated `AuthInfo` to validate `apiKey` and `organizationId` a bit better
- renamed `OPEN_AI_ORGANIZATION_ID` -> `OPENAI_ORGANIZATION_ID`
- updated dependencies
- updated docs