### PR TITLE
com.openai.unity 2.2.5

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Documentation~/README.md
+++ b/OpenAI/Packages/com.openai.unity/Documentation~/README.md
@@ -331,7 +331,6 @@ foreach (var (path, texture) in results)
 }
 ```
 
-
 ### [Files](https://beta.openai.com/docs/api-reference/files)
 
 Files are used to upload documents that can be used with features like [Fine-tuning](#fine-tuning).

--- a/OpenAI/Packages/com.openai.unity/Documentation~/README.md
+++ b/OpenAI/Packages/com.openai.unity/Documentation~/README.md
@@ -316,6 +316,22 @@ foreach (var (path, texture) in results)
 }
 ```
 
+Alternatively, the endpoint can directly take a Texture2D with Read/Write enabled and Compression set to None. 
+
+```csharp
+var api = new OpenAIClient();
+var results = await api.ImagesEndPoint.CreateImageVariationAsync(imageTexture, 1, ImageSize.Small);
+// imageTexture is of type Texture2D 
+foreach (var (path, texture) in results)
+{
+    Debug.Log(path);
+    // path == file://path/to/image.png
+    Assert.IsNotNull(texture);
+    // texture == The preloaded Texture2D
+}
+```
+
+
 ### [Files](https://beta.openai.com/docs/api-reference/files)
 
 Files are used to upload documents that can be used with features like [Fine-tuning](#fine-tuning).

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageVariationRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageVariationRequest.cs
@@ -32,7 +32,7 @@ namespace OpenAI.Images
         /// Constructor.
         /// </summary>
         /// <param name="texture">
-        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// The texture to edit. Must be a valid PNG file, less than 4MB, and square. Read/Write should be enabled and Compression set to None.
         /// </param>
         /// <param name="numberOfResults">
         /// The number of images to generate. Must be between 1 and 10.

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
@@ -165,8 +165,8 @@ namespace OpenAI.Images
         /// <summary>
         /// Creates a variation of a given image.
         /// </summary>
-        /// <param name="imagePath">
-        /// The image to edit. Must be a valid PNG file, less than 4MB, and square.
+        /// <param name="texture">
+        /// The texture to edit. Must be a valid PNG file, less than 4MB, and square. Read/Write should be enabled and Compression set to None.
         /// </param>
         /// <param name="numberOfResults">
         /// The number of images to generate. Must be between 1 and 10.
@@ -180,8 +180,8 @@ namespace OpenAI.Images
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(Texture2D imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
-            => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user), cancellationToken);
+        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(Texture2D texture, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
+            => await CreateImageVariationAsync(new ImageVariationRequest(texture, numberOfResults, size, user), cancellationToken);
 
         /// <summary>
         /// Creates a variation of a given image.

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",


### PR DESCRIPTION
- Renamed `CreateImageVariationAsync` parameter `imagePath` -> `texture`
- Add param description in the documentation that the texture should have read/write enabled and compression set to none. 
- Updated docs with Texture2D example 