### PR TITLE
com.openai.unity 3.0.2

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatRequest.cs
@@ -36,6 +36,7 @@ namespace OpenAI.Chat
             TopP = topP;
             Number = number;
             Stops = stops;
+            MaxTokens = maxTokens;
             PresencePenalty = presencePenalty;
             FrequencyPenalty = frequencyPenalty;
             User = user;

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "3.0.1",
+  "version": "3.0.2",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",


### PR DESCRIPTION
- fixes #38 max token parameter not being set in constructor.