### PR TITLE
com.openai.unity 4.6.0

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/AbstractBaseImageRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/AbstractBaseImageRequest.cs
@@ -1,0 +1,78 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Newtonsoft.Json;
+using System;
+
+namespace OpenAI.Images
+{
+    /// <summary>
+    /// Abstract base image class for making requests.
+    /// </summary>
+    public abstract class AbstractBaseImageRequest
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="Images.ResponseFormat.Url"/>
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        protected AbstractBaseImageRequest(int numberOfResults = 1, ImageSize size = ImageSize.Large, ResponseFormat responseFormat = Images.ResponseFormat.Url, string user = null)
+        {
+            Number = numberOfResults;
+
+            Size = size switch
+            {
+                ImageSize.Small => "256x256",
+                ImageSize.Medium => "512x512",
+                ImageSize.Large => "1024x1024",
+                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
+            };
+
+            User = user;
+            ResponseFormat = responseFormat switch
+            {
+                Images.ResponseFormat.Url => "url",
+                Images.ResponseFormat.B64_Json => "b64_json",
+                _ => throw new ArgumentOutOfRangeException(nameof(responseFormat), responseFormat, null)
+            };
+        }
+
+        /// <summary>
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </summary>
+        [JsonProperty("n")]
+        public int Number { get; }
+
+        /// <summary>
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="Images.ResponseFormat.Url"/>
+        /// </summary>
+        [JsonProperty("response_format")]
+        public string ResponseFormat { get; }
+
+        /// <summary>
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </summary>
+        [JsonProperty("size")]
+        public string Size { get; }
+
+        /// <summary>
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </summary>
+        [JsonProperty("user")]
+        public string User { get; }
+    }
+}

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/AbstractBaseImageRequest.cs.meta
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/AbstractBaseImageRequest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0dfa3564a84c2c14d879b69c33682a7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 84a7eb8fc6eba7540bf56cea8e12249c, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageEditRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageEditRequest.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace OpenAI.Images
 {
-    public sealed class ImageEditRequest : IDisposable
+    public sealed class ImageEditRequest : AbstractBaseImageRequest, IDisposable
     {
         /// <summary>
         /// Constructor.
@@ -27,8 +27,18 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(string imagePath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            : this(imagePath, null, prompt, numberOfResults, size, user)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="Images.ResponseFormat.Url"/>
+        /// </param>
+        public ImageEditRequest(
+            string imagePath,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null, ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : this(imagePath, null, prompt, numberOfResults, size, user, responseFormat)
         {
         }
 
@@ -55,7 +65,19 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(string imagePath, string maskPath, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        public ImageEditRequest(
+            string imagePath,
+            string maskPath,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
             : this(
                 File.OpenRead(imagePath),
                 Path.GetFileName(imagePath),
@@ -64,7 +86,8 @@ namespace OpenAI.Images
                 prompt,
                 numberOfResults,
                 size,
-                user)
+                user,
+                responseFormat)
         {
         }
 
@@ -87,8 +110,19 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(Texture2D texture, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            : this(texture, null, prompt, numberOfResults, size, user)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        public ImageEditRequest(
+            Texture2D texture,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : this(texture, null, prompt, numberOfResults, size, user, responseFormat)
         {
         }
 
@@ -115,16 +149,29 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(Texture2D texture, Texture2D mask, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        public ImageEditRequest(
+            Texture2D texture,
+            Texture2D mask,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
             : this(
                 new MemoryStream(texture.EncodeToPNG()),
-                $"{texture.name}.png",
+                !string.IsNullOrWhiteSpace(texture.name) ? $"{texture.name}.png" : null,
                 mask != null ? new MemoryStream(mask.EncodeToPNG()) : null,
-                mask != null ? $"{mask.name}.png" : null,
+                mask != null ? !string.IsNullOrWhiteSpace(mask.name) ? $"{mask.name}.png" : null : null,
                 prompt,
                 numberOfResults,
                 size,
-                user)
+                user,
+                responseFormat)
         {
         }
 
@@ -148,8 +195,20 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(Stream image, string imageName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
-            : this(image, imageName, null, null, prompt, numberOfResults, size, user)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        public ImageEditRequest(
+            Stream image,
+            string imageName,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : this(image, imageName, null, null, prompt, numberOfResults, size, user, responseFormat)
         {
         }
 
@@ -178,13 +237,29 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
-        public ImageEditRequest(Stream image, string imageName, Stream mask, string maskName, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        public ImageEditRequest(
+            Stream image,
+            string imageName,
+            Stream mask,
+            string maskName,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : base(numberOfResults, size, responseFormat, user)
         {
             Image = image;
 
             if (string.IsNullOrWhiteSpace(imageName))
             {
-                imageName = "image.png";
+                const string defaultImageName = "image.png";
+                imageName = defaultImageName;
             }
 
             ImageName = imageName;
@@ -195,7 +270,8 @@ namespace OpenAI.Images
 
                 if (string.IsNullOrWhiteSpace(maskName))
                 {
-                    maskName = "mask.png";
+                    const string defaultMaskName = "mask.png";
+                    maskName = defaultMaskName;
                 }
 
                 MaskName = maskName;
@@ -212,18 +288,6 @@ namespace OpenAI.Images
             {
                 throw new ArgumentOutOfRangeException(nameof(numberOfResults), "The number of results must be between 1 and 10");
             }
-
-            Number = numberOfResults;
-
-            Size = size switch
-            {
-                ImageSize.Small => "256x256",
-                ImageSize.Medium => "512x512",
-                ImageSize.Large => "1024x1024",
-                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
-            };
-
-            User = user;
         }
 
         ~ImageEditRequest() => Dispose(false);
@@ -248,21 +312,6 @@ namespace OpenAI.Images
         /// A text description of the desired image(s). The maximum length is 1000 characters.
         /// </summary>
         public string Prompt { get; }
-
-        /// <summary>
-        /// The number of images to generate. Must be between 1 and 10.
-        /// </summary>
-        public int Number { get; }
-
-        /// <summary>
-        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
-        /// </summary>
-        public string Size { get; }
-
-        /// <summary>
-        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
-        /// </summary>
-        public string User { get; }
 
         private void Dispose(bool disposing)
         {

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageGenerationRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageGenerationRequest.cs
@@ -8,17 +8,31 @@ namespace OpenAI.Images
     /// <summary>
     /// Creates an image given a prompt.
     /// </summary>
-    public sealed class ImageGenerationRequest
+    public sealed class ImageGenerationRequest : AbstractBaseImageRequest
     {
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="prompt">A text description of the desired image(s). The maximum length is 1000 characters.</param>
-        /// <param name="numberOfResults">The number of images to generate. Must be between 1 and 10.</param>
-        /// <param name="size">The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.</param>
-        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
+        /// <param name="prompt">
+        /// A text description of the desired image(s). The maximum length is 1000 characters.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned.
+        /// Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public ImageGenerationRequest(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null)
+        public ImageGenerationRequest(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, ResponseFormat responseFormat = Images.ResponseFormat.Url)
+            : base(numberOfResults, size, responseFormat, user)
         {
             if (prompt.Length > 1000)
             {
@@ -31,18 +45,6 @@ namespace OpenAI.Images
             {
                 throw new ArgumentOutOfRangeException(nameof(numberOfResults), "The number of results must be between 1 and 10");
             }
-
-            Number = numberOfResults;
-
-            Size = size switch
-            {
-                ImageSize.Small => "256x256",
-                ImageSize.Medium => "512x512",
-                ImageSize.Large => "1024x1024",
-                _ => throw new ArgumentOutOfRangeException(nameof(size), size, null)
-            };
-
-            User = user;
         }
 
         /// <summary>
@@ -50,23 +52,5 @@ namespace OpenAI.Images
         /// </summary>
         [JsonProperty("prompt")]
         public string Prompt { get; }
-
-        /// <summary>
-        /// The number of images to generate. Must be between 1 and 10.
-        /// </summary>
-        [JsonProperty("n")]
-        public int Number { get; }
-
-        /// <summary>
-        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
-        /// </summary>
-        [JsonProperty("size")]
-        public string Size { get; }
-
-        /// <summary>
-        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
-        /// </summary>
-        [JsonProperty("user")]
-        public string User { get; }
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageResult.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageResult.cs
@@ -7,12 +7,18 @@ namespace OpenAI.Images
     internal class ImageResult
     {
         [JsonConstructor]
-        public ImageResult(string url)
+        public ImageResult(
+            [JsonProperty("url")] string url,
+            [JsonProperty("b64_json")] string b64_json)
         {
             Url = url;
+            B64_Json = b64_json;
         }
 
         [JsonProperty("url")]
         public string Url { get; }
+
+        [JsonProperty("b64_json")]
+        public string B64_Json { get; private set; }
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
@@ -1,6 +1,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Newtonsoft.Json;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -28,15 +29,35 @@ namespace OpenAI.Images
         /// <summary>
         /// Creates an image given a prompt.
         /// </summary>
-        /// <param name="prompt">A text description of the desired image(s). The maximum length is 1000 characters.</param>
-        /// <param name="numberOfResults">The number of images to generate. Must be between 1 and 10.</param>
-        /// <param name="size">The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.</param>
-        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
-        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <param name="prompt">
+        /// A text description of the desired image(s). The maximum length is 1000 characters.
+        /// </param>
+        /// <param name="numberOfResults">
+        /// The number of images to generate. Must be between 1 and 10.
+        /// </param>
+        /// <param name="size">
+        /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
+        /// </param>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Optional, <see cref="CancellationToken"/>.
+        /// </param>
         /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyDictionary<string, Texture2D>> GenerateImageAsync(string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
-            => await GenerateImageAsync(new ImageGenerationRequest(prompt, numberOfResults, size, user), cancellationToken);
+        public async Task<IReadOnlyDictionary<string, Texture2D>> GenerateImageAsync(
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            CancellationToken cancellationToken = default)
+            => await GenerateImageAsync(new ImageGenerationRequest(prompt, numberOfResults, size, user, responseFormat), cancellationToken);
 
         /// <summary>
         /// Creates an image given a prompt.
@@ -72,12 +93,30 @@ namespace OpenAI.Images
         /// <param name="size">
         /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
         /// </param>
-        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
-        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Optional, <see cref="CancellationToken"/>.
+        /// </param>
+        /// <returns>
+        /// A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.
+        /// </returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageEditAsync(string image, string mask, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
-            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user), cancellationToken);
+        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageEditAsync(
+            string image,
+            string mask,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            CancellationToken cancellationToken = default)
+            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user, responseFormat), cancellationToken);
 
         /// <summary>
         /// Creates an edited or extended image given an original image and a prompt.
@@ -99,12 +138,30 @@ namespace OpenAI.Images
         /// <param name="size">
         /// The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024.
         /// </param>
-        /// <param name="user">A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.</param>
-        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
+        /// <param name="user">
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Optional, <see cref="CancellationToken"/>.
+        /// </param>
+        /// <returns>
+        /// A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.
+        /// </returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageEditAsync(Texture2D image, Texture2D mask, string prompt, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
-            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user), cancellationToken);
+        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageEditAsync(
+            Texture2D image,
+            Texture2D mask,
+            string prompt,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            CancellationToken cancellationToken = default)
+            => await CreateImageEditAsync(new ImageEditRequest(image, mask, prompt, numberOfResults, size, user, responseFormat), cancellationToken);
 
         /// <summary>
         /// Creates an edited or extended image given an original image and a prompt.
@@ -130,6 +187,7 @@ namespace OpenAI.Images
             content.Add(new StringContent(request.Prompt), "prompt");
             content.Add(new StringContent(request.Number.ToString()), "n");
             content.Add(new StringContent(request.Size), "size");
+            content.Add(new StringContent(request.ResponseFormat), "response_format");
 
             if (!string.IsNullOrWhiteSpace(request.User))
             {
@@ -157,11 +215,21 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(string imagePath, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
-            => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user), cancellationToken);
+        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(
+            string imagePath,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            CancellationToken cancellationToken = default)
+            => await CreateImageVariationAsync(new ImageVariationRequest(imagePath, numberOfResults, size, user, responseFormat), cancellationToken);
 
         /// <summary>
         /// Creates a variation of a given image.
@@ -178,11 +246,21 @@ namespace OpenAI.Images
         /// <param name="user">
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
+        /// <param name="responseFormat">
+        /// The format in which the generated images are returned. Must be one of url or b64_json.
+        /// <para/> Defaults to <see cref="ResponseFormat.Url"/>
+        /// </param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>A dictionary of file urls and the preloaded <see cref="Texture2D"/> that were downloaded.</returns>
         /// <exception cref="HttpRequestException"></exception>
-        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(Texture2D texture, int numberOfResults = 1, ImageSize size = ImageSize.Large, string user = null, CancellationToken cancellationToken = default)
-            => await CreateImageVariationAsync(new ImageVariationRequest(texture, numberOfResults, size, user), cancellationToken);
+        public async Task<IReadOnlyDictionary<string, Texture2D>> CreateImageVariationAsync(
+            Texture2D texture,
+            int numberOfResults = 1,
+            ImageSize size = ImageSize.Large,
+            string user = null,
+            ResponseFormat responseFormat = ResponseFormat.Url,
+            CancellationToken cancellationToken = default)
+            => await CreateImageVariationAsync(new ImageVariationRequest(texture, numberOfResults, size, user, responseFormat), cancellationToken);
 
         /// <summary>
         /// Creates a variation of a given image.
@@ -199,6 +277,7 @@ namespace OpenAI.Images
             content.Add(new ByteArrayContent(imageData.ToArray()), "image", request.ImageName);
             content.Add(new StringContent(request.Number.ToString()), "n");
             content.Add(new StringContent(request.Size), "size");
+            content.Add(new StringContent(request.ResponseFormat), "response_format");
 
             if (!string.IsNullOrWhiteSpace(request.User))
             {
@@ -230,15 +309,37 @@ namespace OpenAI.Images
 
             async Task DownloadAsync(ImageResult result)
             {
-                var texture = await Rest.DownloadTextureAsync(result.Url, cancellationToken: cancellationToken);
+                string resultString;
+                string localFilePath;
 
-                if (Rest.TryGetDownloadCacheItem(result.Url, out var localFilePath))
+                if (string.IsNullOrWhiteSpace(result.Url))
+                {
+                    resultString = result.B64_Json;
+                    var imageData = Convert.FromBase64String(resultString);
+                    await Rest.ValidateCacheDirectoryAsync();
+
+                    if (!Rest.TryGetDownloadCacheItem(resultString, out localFilePath))
+                    {
+                        await using FileStream fileStream = new FileStream(localFilePath, FileMode.Create, FileAccess.ReadWrite);
+                        await fileStream.WriteAsync(imageData, cancellationToken);
+                    }
+
+                    resultString = $"file://{localFilePath}";
+                }
+                else
+                {
+                    resultString = result.Url;
+                }
+
+                var texture = await Rest.DownloadTextureAsync(resultString, cancellationToken: cancellationToken);
+
+                if (Rest.TryGetDownloadCacheItem(resultString, out localFilePath))
                 {
                     images.TryAdd(localFilePath, texture);
                 }
                 else
                 {
-                    Debug.LogError($"Failed to find cached item for {result.Url}");
+                    Debug.LogError($"Failed to find cached item for {resultString}");
                 }
             }
 

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ResponseFormat.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ResponseFormat.cs
@@ -1,0 +1,10 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace OpenAI.Images
+{
+    public enum ResponseFormat
+    {
+        Url,
+        B64_Json
+    }
+}

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ResponseFormat.cs.meta
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ResponseFormat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dce2f2521ac1b84b8bff1bdb2feeeb3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 84a7eb8fc6eba7540bf56cea8e12249c, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
@@ -2,6 +2,7 @@
 
 using NUnit.Framework;
 using OpenAI.Images;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -30,7 +31,24 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_2_CreateImageEdit_Path()
+        public async Task Test_2_GenerateImages_B64_Json()
+        {
+            var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+            Assert.IsNotNull(api.ImagesEndPoint);
+
+            var results = await api.ImagesEndPoint.GenerateImageAsync("A house riding a velociraptor", 1, ImageSize.Small, responseFormat: ResponseFormat.B64_Json);
+
+            Assert.IsNotNull(results);
+            Assert.NotZero(results.Count);
+
+            foreach (var result in results)
+            {
+                Console.WriteLine(result);
+            }
+        }
+
+        [Test]
+        public async Task Test_3_CreateImageEdit_Path()
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ImagesEndPoint);
@@ -49,7 +67,7 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_3_CreateImageEdit_Texture()
+        public async Task Test_4_CreateImageEdit_Texture()
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ImagesEndPoint);
@@ -70,7 +88,28 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_4_CreateImageEdit_MaskAsTransparency()
+        public async Task Test_5_CreateImageEdit_Texture_B64_Json()
+        {
+            var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+            Assert.IsNotNull(api.ImagesEndPoint);
+            var imageAssetPath = AssetDatabase.GUIDToAssetPath("230fd778637d3d84d81355c8c13b1999");
+            var image = AssetDatabase.LoadAssetAtPath<Texture2D>(imageAssetPath);
+            var maskAssetPath = AssetDatabase.GUIDToAssetPath("0be6be2fad590cc47930495d2ca37dd6");
+            var mask = AssetDatabase.LoadAssetAtPath<Texture2D>(maskAssetPath);
+            var results = await api.ImagesEndPoint.CreateImageEditAsync(image, mask, "A sunlit indoor lounge area with a pool containing a flamingo", 1, ImageSize.Small, responseFormat: ResponseFormat.B64_Json);
+
+            Assert.IsNotNull(results);
+            Assert.NotZero(results.Count);
+
+            foreach (var (path, texture) in results)
+            {
+                Debug.Log(path);
+                Assert.IsNotNull(texture);
+            }
+        }
+
+        [Test]
+        public async Task Test_6_CreateImageEdit_MaskAsTransparency()
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ImagesEndPoint);
@@ -89,7 +128,7 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_5_CreateImageVariation_Path()
+        public async Task Test_7_CreateImageVariation_Path()
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ImagesEndPoint);
@@ -107,13 +146,32 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_6_CreateImageVariation_Texture()
+        public async Task Test_8_CreateImageVariation_Texture()
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ImagesEndPoint);
             var imageAssetPath = AssetDatabase.GUIDToAssetPath("230fd778637d3d84d81355c8c13b1999");
             var image = AssetDatabase.LoadAssetAtPath<Texture2D>(imageAssetPath);
             var results = await api.ImagesEndPoint.CreateImageVariationAsync(image, 1, ImageSize.Small);
+
+            Assert.IsNotNull(results);
+            Assert.NotZero(results.Count);
+
+            foreach (var (path, texture) in results)
+            {
+                Debug.Log(path);
+                Assert.IsNotNull(texture);
+            }
+        }
+
+        [Test]
+        public async Task Test_9_CreateImageVariation_Texture_B64_Json()
+        {
+            var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
+            Assert.IsNotNull(api.ImagesEndPoint);
+            var imageAssetPath = AssetDatabase.GUIDToAssetPath("230fd778637d3d84d81355c8c13b1999");
+            var image = AssetDatabase.LoadAssetAtPath<Texture2D>(imageAssetPath);
+            var results = await api.ImagesEndPoint.CreateImageVariationAsync(image, 1, ImageSize.Small, responseFormat: ResponseFormat.B64_Json);
 
             Assert.IsNotNull(results);
             Assert.NotZero(results.Count);

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "4.5.4",
+  "version": "4.6.0",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.0.2",
-    "com.utilities.rest": "1.3.0",
+    "com.utilities.rest": "1.3.1",
     "com.utilities.encoder.wav": "1.0.2"
   },
   "publishConfig": {

--- a/OpenAI/ProjectSettings/ProjectVersion.txt
+++ b/OpenAI/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.18f1
-m_EditorVersionWithRevision: 2021.3.18f1 (3129e69bc0c7)
+m_EditorVersion: 2021.3.22f1
+m_EditorVersionWithRevision: 2021.3.22f1 (b6c551784ba3)


### PR DESCRIPTION
- Added [`response_format`](https://platform.openai.com/docs/api-reference/images/create#images/create-response_format) to `ImageGenerationRequest`
- Refactored Image Requests with AbstractBaseImageRequest