### PR TITLE
com.openai.unity 4.7.0

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatPrompt.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatPrompt.cs
@@ -1,27 +1,43 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Newtonsoft.Json;
+using System;
 
 namespace OpenAI.Chat
 {
+    [Obsolete("Use OpenAI.Chat.Message instead")]
     public sealed class ChatPrompt
     {
+        [Obsolete("Use OpenAI.Chat.Message instead")]
+        public ChatPrompt(string role, string content)
+        {
+            Role = role.ToLower() switch
+            {
+                "system" => Role.System,
+                "assistant" => Role.Assistant,
+                "user" => Role.User,
+                _ => throw new ArgumentException(nameof(role))
+            };
+            Content = content;
+        }
+
         [JsonConstructor]
         public ChatPrompt(
-            [JsonProperty("role")] string role,
-            [JsonProperty("content")] string content
-        )
+            [JsonProperty("role")] Role role,
+            [JsonProperty("content")] string content)
         {
             Role = role;
             Content = content;
         }
 
         [JsonProperty("role")]
-        public string Role { get; }
+        public Role Role { get; }
 
         [JsonProperty("content")]
         public string Content { get; }
 
-        public override string ToString() => JsonConvert.SerializeObject(this);
+        public static implicit operator ChatPrompt(Message message) => new ChatPrompt(message.Role, message.Content);
+
+        public static implicit operator Message(ChatPrompt message) => new Message(message.Role, message.Content);
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatPrompt.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatPrompt.cs
@@ -22,6 +22,7 @@ namespace OpenAI.Chat
         }
 
         [JsonConstructor]
+        [Obsolete("Use OpenAI.Chat.Message instead")]
         public ChatPrompt(
             [JsonProperty("role")] Role role,
             [JsonProperty("content")] string content)

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatRequest.cs
@@ -13,9 +13,12 @@ namespace OpenAI.Chat
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="messages"></param>
+        /// <param name="messages">
+        /// The list of messages for the current chat session.
+        /// </param>
         /// <param name="model">
-        /// ID of the model to use. Currently, only gpt-3.5-turbo and gpt-3.5-turbo-0301 are supported.
+        /// ID of the model to use.<br/>
+        /// Currently, only gpt-4, gpt-3.5-turbo and gpt-3.5-turbo-0301 are supported.
         /// </param>
         /// <param name="temperature">
         /// What sampling temperature to use, between 0 and 2.
@@ -67,7 +70,7 @@ namespace OpenAI.Chat
         /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
         /// </param>
         public ChatRequest(
-            IEnumerable<ChatPrompt> messages,
+            IEnumerable<Message> messages,
             Model model = null,
             double? temperature = null,
             double? topP = null,
@@ -105,8 +108,24 @@ namespace OpenAI.Chat
             User = user;
         }
 
+        [Obsolete("Use ChatRequest(IEnumerable<Message> messages) instead")]
+        public ChatRequest(
+            IEnumerable<ChatPrompt> messages,
+            Model model = null,
+            double? temperature = null,
+            double? topP = null,
+            int? number = null,
+            string[] stops = null,
+            int? maxTokens = null,
+            double? presencePenalty = null,
+            double? frequencyPenalty = null,
+            Dictionary<string, double> logitBias = null,
+            string user = null)
+        => throw new NotImplementedException();
+
         /// <summary>
-        /// ID of the model to use. Currently, only gpt-3.5-turbo and gpt-3.5-turbo-0301 are supported.
+        /// ID of the model to use.<br/>
+        /// Currently, only gpt-4, gpt-3.5-turbo and gpt-3.5-turbo-0301 are supported.
         /// </summary>
         [JsonProperty("model")]
         public string Model { get; }
@@ -115,7 +134,7 @@ namespace OpenAI.Chat
         /// The messages to generate chat completions for, in the chat format.
         /// </summary>
         [JsonProperty("messages")]
-        public IReadOnlyList<ChatPrompt> Messages { get; }
+        public IReadOnlyList<Message> Messages { get; }
 
         /// <summary>
         /// What sampling temperature to use, between 0 and 2.

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatResponse.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatResponse.cs
@@ -45,7 +45,5 @@ namespace OpenAI.Chat
 
         [JsonIgnore]
         public Choice FirstChoice => Choices.FirstOrDefault();
-
-        public override string ToString() => JsonConvert.SerializeObject(this);
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/Choice.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/Choice.cs
@@ -31,7 +31,7 @@ namespace OpenAI.Chat
         [JsonProperty("index")]
         public int Index { get; }
 
-        public override string ToString() => Message?.ToString() ?? Delta.Content;
+        public override string ToString() => Message?.Content ?? Delta.Content;
 
         public static implicit operator string(Choice choice) => choice.ToString();
     }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/Delta.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/Delta.cs
@@ -8,7 +8,7 @@ namespace OpenAI.Chat
     {
         [JsonConstructor]
         public Delta(
-            [JsonProperty("role")] string role,
+            [JsonProperty("role")] Role role,
             [JsonProperty("content")] string content)
         {
             Role = role;
@@ -16,9 +16,11 @@ namespace OpenAI.Chat
         }
 
         [JsonProperty("role")]
-        public string Role { get; }
+        public Role Role { get; }
 
         [JsonProperty("content")]
         public string Content { get; }
+
+        public override string ToString() => Content;
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/Message.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/Message.cs
@@ -2,22 +2,24 @@
 
 using Newtonsoft.Json;
 using System;
+using UnityEngine;
 
 namespace OpenAI.Chat
 {
+    [Serializable]
     public sealed class Message
     {
         [Obsolete("Use new constructor with enum Role")]
         public Message(string role, string content)
         {
-            Role = role.ToLower() switch
+            this.role = role.ToLower() switch
             {
                 "system" => Role.System,
                 "assistant" => Role.Assistant,
                 "user" => Role.User,
                 _ => throw new ArgumentException(nameof(role))
             };
-            Content = content;
+            this.content = content;
         }
 
         [JsonConstructor]
@@ -25,15 +27,22 @@ namespace OpenAI.Chat
             [JsonProperty("role")] Role role,
             [JsonProperty("content")] string content)
         {
-            Role = role;
-            Content = content;
+            this.role = role;
+            this.content = content;
         }
 
+        [SerializeField]
+        private Role role;
+
         [JsonProperty("role")]
-        public Role Role { get; }
+        public Role Role => role;
+
+        [SerializeField]
+        [TextArea(1, 30)]
+        private string content;
 
         [JsonProperty("content")]
-        public string Content { get; }
+        public string Content => content;
 
         public static implicit operator string(Message message) => message.Content;
     }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/Message.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/Message.cs
@@ -1,14 +1,28 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Newtonsoft.Json;
+using System;
 
 namespace OpenAI.Chat
 {
     public sealed class Message
     {
+        [Obsolete("Use new constructor with enum Role")]
+        public Message(string role, string content)
+        {
+            Role = role.ToLower() switch
+            {
+                "system" => Role.System,
+                "assistant" => Role.Assistant,
+                "user" => Role.User,
+                _ => throw new ArgumentException(nameof(role))
+            };
+            Content = content;
+        }
+
         [JsonConstructor]
         public Message(
-            [JsonProperty("role")] string role,
+            [JsonProperty("role")] Role role,
             [JsonProperty("content")] string content)
         {
             Role = role;
@@ -16,12 +30,10 @@ namespace OpenAI.Chat
         }
 
         [JsonProperty("role")]
-        public string Role { get; }
+        public Role Role { get; }
 
         [JsonProperty("content")]
         public string Content { get; }
-
-        public override string ToString() => Content;
 
         public static implicit operator string(Message message) => message.Content;
     }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/Role.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/Role.cs
@@ -1,0 +1,16 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.Serialization;
+
+namespace OpenAI.Chat
+{
+    public enum Role
+    {
+        [EnumMember(Value = "system")]
+        System = 1,
+        [EnumMember(Value = "assistant")]
+        Assistant = 2,
+        [EnumMember(Value = "user")]
+        User = 3,
+    }
+}

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/Role.cs.meta
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/Role.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8a77eac2dd25c543a9e6d9e6da233cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 84a7eb8fc6eba7540bf56cea8e12249c, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OpenAI/Packages/com.openai.unity/Runtime/OpenAIClient.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/OpenAIClient.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using OpenAI.Audio;
 using OpenAI.Chat;
 using OpenAI.Completions;
@@ -11,6 +13,7 @@ using OpenAI.FineTuning;
 using OpenAI.Images;
 using OpenAI.Models;
 using OpenAI.Moderations;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Authentication;
@@ -64,7 +67,11 @@ namespace OpenAI
             Client = SetupClient();
             JsonSerializationOptions = new JsonSerializerSettings
             {
-                DefaultValueHandling = DefaultValueHandling.Ignore
+                DefaultValueHandling = DefaultValueHandling.Ignore,
+                Converters = new List<JsonConverter>
+                {
+                    new StringEnumConverter(new CamelCaseNamingStrategy())
+                }
             };
             ModelsEndpoint = new ModelsEndpoint(this);
             CompletionsEndpoint = new CompletionsEndpoint(this);

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Chat.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Chat.cs
@@ -16,14 +16,14 @@ namespace OpenAI.Tests
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ChatEndpoint);
-            var chatPrompts = new List<ChatPrompt>
+            var messages = new List<Message>
             {
-                new ChatPrompt("system", "You are a helpful assistant."),
-                new ChatPrompt("user", "Who won the world series in 2020?"),
-                new ChatPrompt("assistant", "The Los Angeles Dodgers won the World Series in 2020."),
-                new ChatPrompt("user", "Where was it played?"),
+                new Message(Role.System, "You are a helpful assistant."),
+                new Message(Role.User, "Who won the world series in 2020?"),
+                new Message(Role.Assistant, "The Los Angeles Dodgers won the World Series in 2020."),
+                new Message(Role.User, "Where was it played?"),
             };
-            var chatRequest = new ChatRequest(chatPrompts, Model.GPT3_5_Turbo);
+            var chatRequest = new ChatRequest(messages, Model.GPT3_5_Turbo);
             var result = await api.ChatEndpoint.GetCompletionAsync(chatRequest);
             Assert.IsNotNull(result);
             Assert.NotNull(result.Choices);
@@ -36,14 +36,14 @@ namespace OpenAI.Tests
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ChatEndpoint);
-            var chatPrompts = new List<ChatPrompt>
+            var messages = new List<Message>
             {
-                new ChatPrompt("system", "You are a helpful assistant."),
-                new ChatPrompt("user", "Who won the world series in 2020?"),
-                new ChatPrompt("assistant", "The Los Angeles Dodgers won the World Series in 2020."),
-                new ChatPrompt("user", "Where was it played?"),
+                new Message(Role.System, "You are a helpful assistant."),
+                new Message(Role.User, "Who won the world series in 2020?"),
+                new Message(Role.Assistant, "The Los Angeles Dodgers won the World Series in 2020."),
+                new Message(Role.User, "Where was it played?"),
             };
-            var chatRequest = new ChatRequest(chatPrompts, Model.GPT3_5_Turbo);
+            var chatRequest = new ChatRequest(messages, Model.GPT3_5_Turbo);
             var allContent = new List<string>();
 
             await api.ChatEndpoint.StreamCompletionAsync(chatRequest, result =>
@@ -54,7 +54,7 @@ namespace OpenAI.Tests
                 allContent.Add(result.FirstChoice);
             });
 
-            Debug.Log(string.Join("", allContent));
+            Debug.Log(string.Join(string.Empty, allContent));
         }
 
         [Test]
@@ -62,14 +62,14 @@ namespace OpenAI.Tests
         {
             var api = new OpenAIClient(OpenAIAuthentication.LoadFromEnv());
             Assert.IsNotNull(api.ChatEndpoint);
-            var chatPrompts = new List<ChatPrompt>
+            var messages = new List<Message>
             {
-                new ChatPrompt("system", "You are a helpful assistant."),
-                new ChatPrompt("user", "Who won the world series in 2020?"),
-                new ChatPrompt("assistant", "The Los Angeles Dodgers won the World Series in 2020."),
-                new ChatPrompt("user", "Where was it played?"),
+                new Message(Role.System, "You are a helpful assistant."),
+                new Message(Role.User, "Who won the world series in 2020?"),
+                new Message(Role.Assistant, "The Los Angeles Dodgers won the World Series in 2020."),
+                new Message(Role.User, "Where was it played?"),
             };
-            var chatRequest = new ChatRequest(chatPrompts, Model.GPT3_5_Turbo);
+            var chatRequest = new ChatRequest(messages, Model.GPT3_5_Turbo);
             var allContent = new List<string>();
 
             await foreach (var result in api.ChatEndpoint.StreamCompletionEnumerableAsync(chatRequest))
@@ -80,7 +80,7 @@ namespace OpenAI.Tests
                 allContent.Add(result.FirstChoice);
             }
 
-            Debug.Log(string.Join("", allContent));
+            Debug.Log(string.Join(string.Empty, allContent));
         }
     }
 }

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -1,9 +1,9 @@
 {
   "name": "com.openai.unity",
   "displayName": "OpenAI",
-  "description": "A OpenAI package for the Unity Game Engine to use GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
+  "description": "A OpenAI package for the Unity Game Engine to use GPT-4, GPT-3.5, GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "4.6.0",
+  "version": "4.7.0",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",


### PR DESCRIPTION
- Deprecated `ChatPrompt` -> `Message`
- Added `Role` enum for `Chat.Messages` and `Chat.Delta`
- Updated `ChatRequest` constructor to use `IEnumerable<Message> messages`
- Updated `ChatRequest.Messages` to `IReadonlyList<Message>`
- Updated unit tests