### PR TITLE
com.openai.unity 7.7.5

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Common/FunctionParameterAttribute.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Common/FunctionParameterAttribute.cs
@@ -7,6 +7,10 @@ namespace OpenAI
     [AttributeUsage(AttributeTargets.Parameter)]
     public sealed class FunctionParameterAttribute : Attribute
     {
+        /// <summary>
+        /// Function parameter attribute to help describe the parameter for the function.
+        /// </summary>
+        /// <param name="description">The description of the parameter and its usage.</param>
         public FunctionParameterAttribute(string description)
         {
             Description = description;

--- a/OpenAI/Packages/com.openai.unity/Runtime/Common/FunctionPropertyAttribute.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Common/FunctionPropertyAttribute.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace OpenAI
 {
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
     public sealed class FunctionPropertyAttribute : Attribute
     {
         /// <summary>

--- a/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TypeExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TypeExtensions.cs
@@ -62,10 +62,9 @@ namespace OpenAI.Extensions
             return schema;
         }
 
-        public static JObject GenerateJsonSchema(this Type type, JObject rootSchema = null)
+        public static JObject GenerateJsonSchema(this Type type, JObject rootSchema)
         {
             var schema = new JObject();
-            rootSchema ??= schema;
             var serializer = JsonSerializer.Create(OpenAIClient.JsonSerializationOptions);
 
             if (!type.IsPrimitive &&

--- a/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TypeExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TypeExtensions.cs
@@ -227,10 +227,10 @@ namespace OpenAI.Extensions
                         switch (jsonPropertyAttribute.Required)
                         {
                             case Required.Always:
+                            case Required.AllowNull:
                                 requiredMembers.Add(propertyName);
                                 break;
                             case Required.Default:
-                            case Required.AllowNull:
                             case Required.DisallowNull:
                             default:
                                 requiredMembers.Remove(propertyName);

--- a/OpenAI/Packages/com.openai.unity/Runtime/OpenAIClient.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/OpenAIClient.cs
@@ -114,6 +114,7 @@ namespace OpenAI
         {
             NullValueHandling = NullValueHandling.Ignore,
             DefaultValueHandling = DefaultValueHandling.Ignore,
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             Converters = new List<JsonConverter>
             {
                 new StringEnumConverter(new SnakeCaseNamingStrategy())

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-4, GPT-3.5, GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "7.7.4",
+  "version": "7.7.5",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",
@@ -17,7 +17,7 @@
     "url": "https://github.com/StephenHodgson"
   },
   "dependencies": {
-    "com.utilities.rest": "2.5.3",
+    "com.utilities.rest": "2.5.4",
     "com.utilities.encoder.wav": "1.1.5"
   },
   "samples": [

--- a/OpenAI/Packages/manifest.json
+++ b/OpenAI/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.27",
+    "com.unity.ide.rider": "3.0.28",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.textmeshpro": "3.0.8",
-    "com.utilities.buildpipeline": "1.2.2"
+    "com.utilities.buildpipeline": "1.2.3"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
- Allow FunctionPropertyAttribute to be assignable to fields
- Updated Function schema generation
  - Fall back to complex types, and use $ref for discovered types
  - Fixed schema generation to properly assign unsigned integer types
- Updated com.utilities.rest -> 2.5.4