### PR TITLE
added option for http

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Authentication/OpenAISettings.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Authentication/OpenAISettings.cs
@@ -64,9 +64,9 @@ namespace OpenAI
         /// </summary>
         /// <param name="domain">Base api domain.</param>
         /// <param name="apiVersion">The version of the OpenAI api you want to use.</param>
-        public OpenAISettings(string domain, string apiVersion = OpenAISettingsInfo.DefaultOpenAIApiVersion)
+        public OpenAISettings(string domain, string apiVersion = OpenAISettingsInfo.DefaultOpenAIApiVersion, bool secure = true)
         {
-            Info = new OpenAISettingsInfo(domain, apiVersion);
+            Info = new OpenAISettingsInfo(domain, apiVersion, secure);
             cachedDefault = this;
         }
 

--- a/OpenAI/Packages/com.openai.unity/Runtime/Authentication/OpenAISettingsInfo.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Authentication/OpenAISettingsInfo.cs
@@ -30,7 +30,7 @@ namespace OpenAI
         /// </summary>
         /// <param name="domain">Base api domain.</param>
         /// <param name="apiVersion">The version of the OpenAI api you want to use.</param>
-        public OpenAISettingsInfo(string domain, string apiVersion = DefaultOpenAIApiVersion)
+        public OpenAISettingsInfo(string domain, string apiVersion = DefaultOpenAIApiVersion, bool secure = true)
         {
             if (string.IsNullOrWhiteSpace(domain))
             {
@@ -52,7 +52,7 @@ namespace OpenAI
             ApiVersion = apiVersion;
             DeploymentId = string.Empty;
             BaseRequest = $"/{ApiVersion}/";
-            BaseRequestUrlFormat = $"https://{ResourceName}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{(secure ? "https" : "http")}://{ResourceName}{BaseRequest}{{0}}";
             UseOAuthAuthentication = true;
         }
 


### PR DESCRIPTION
This change enables the use of this package together with LM Studio in server mode, which mimics a subset of the OpenAI API, but does not support https.

Example:
`var api = new OpenAIClient("none", new OpenAISettings(domain: "localhost:1234", secure: false));`