### PR TITLE
com.openai.unity 7.7.8

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Authentication/OpenAISettingsInfo.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Authentication/OpenAISettingsInfo.cs
@@ -7,6 +7,7 @@ namespace OpenAI
 {
     public sealed class OpenAISettingsInfo : ISettingsInfo
     {
+        internal const string Https = "https://";
         internal const string OpenAIDomain = "api.openai.com";
         internal const string DefaultOpenAIApiVersion = "v1";
         internal const string AzureOpenAIDomain = "openai.azure.com";
@@ -21,7 +22,7 @@ namespace OpenAI
             ApiVersion = DefaultOpenAIApiVersion;
             DeploymentId = string.Empty;
             BaseRequest = $"/{ApiVersion}/";
-            BaseRequestUrlFormat = $"https://{ResourceName}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{Https}{ResourceName}{BaseRequest}{{0}}";
             UseOAuthAuthentication = true;
         }
 
@@ -48,11 +49,11 @@ namespace OpenAI
                 apiVersion = DefaultOpenAIApiVersion;
             }
 
-            ResourceName = domain;
+            ResourceName = domain.Contains("http") ? domain : $"{Https}{domain}";
             ApiVersion = apiVersion;
             DeploymentId = string.Empty;
             BaseRequest = $"/{ApiVersion}/";
-            BaseRequestUrlFormat = $"https://{ResourceName}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{ResourceName}{BaseRequest}{{0}}";
             UseOAuthAuthentication = true;
         }
 
@@ -94,7 +95,7 @@ namespace OpenAI
             DeploymentId = deploymentId;
             ApiVersion = apiVersion;
             BaseRequest = $"/openai/deployments/{DeploymentId}/";
-            BaseRequestUrlFormat = $"https://{ResourceName}.{AzureOpenAIDomain}{BaseRequest}{{0}}?api-version={ApiVersion}";
+            BaseRequestUrlFormat = $"{Https}{ResourceName}.{AzureOpenAIDomain}{BaseRequest}{{0}}?api-version={ApiVersion}";
             UseOAuthAuthentication = useActiveDirectoryAuthentication;
         }
 
@@ -106,10 +107,10 @@ namespace OpenAI
 
         public string BaseRequest { get; }
 
-        public string BaseRequestUrlFormat { get; }
+        internal string BaseRequestUrlFormat { get; }
 
-        public bool UseOAuthAuthentication { get; }
+        internal bool UseOAuthAuthentication { get; }
 
-        internal bool IsAzureDeployment => BaseRequestUrlFormat.Contains(AzureOpenAIDomain);
+        public bool IsAzureDeployment => BaseRequestUrlFormat.Contains(AzureOpenAIDomain);
     }
 }

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-4, GPT-3.5, GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "7.7.7",
+  "version": "7.7.8",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",
@@ -17,7 +17,7 @@
     "url": "https://github.com/StephenHodgson"
   },
   "dependencies": {
-    "com.utilities.rest": "2.5.5",
+    "com.utilities.rest": "2.5.6",
     "com.utilities.encoder.wav": "1.1.5"
   },
   "samples": [

--- a/OpenAI/Packages/manifest.json
+++ b/OpenAI/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.unity.ide.rider": "3.0.28",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.textmeshpro": "3.0.8",
-    "com.utilities.buildpipeline": "1.3.2"
+    "com.utilities.buildpipeline": "1.3.4"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
- Updated OpenAISettingsInfo.ctr to allow for domain http protocol override (i.e. http://localhost:8080 or http://0.0.0.0:8080)
- Updated OpenAISettingsInfo.BaseRequest public for easier access when implementing custom proxies.
- Updated OpenAISettingsInfo.IsAzureDeployment public for easier access when implementing custom proxies.
- Updated com.utilities.rest -> 2.5.6