### PR TITLE
com.openai.unity 8.1.0

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Documentation~/README.md
+++ b/OpenAI/Packages/com.openai.unity/Documentation~/README.md
@@ -56,7 +56,7 @@ The recommended installation method is though the unity package manager and [Ope
 
 ### Table of Contents
 
-- [Authentication](#authentication) :new: :warning: :construction:
+- [Authentication](#authentication)
 - [Azure OpenAI](#azure-openai)
   - [Azure Active Directory Authentication](#azure-active-directory-authentication)
 - [OpenAI API Proxy](#openai-api-proxy)
@@ -64,17 +64,17 @@ The recommended installation method is though the unity package manager and [Ope
   - [List Models](#list-models)
   - [Retrieve Models](#retrieve-model)
   - [Delete Fine Tuned Model](#delete-fine-tuned-model)
-- [Assistants](#assistants) :new: :warning: :construction:
+- [Assistants](#assistants) :warning: :construction:
   - [List Assistants](#list-assistants)
   - [Create Assistant](#create-assistant)
   - [Retrieve Assistant](#retrieve-assistant)
   - [Modify Assistant](#modify-assistant)
   - [Delete Assistant](#delete-assistant)
-  - [Assistant Streaming](#assistant-streaming) :new:
-  - [Threads](#threads) :new: :warning: :construction:
+  - [Assistant Streaming](#assistant-streaming) :warning: :construction:
+  - [Threads](#threads) :warning: :construction:
     - [Create Thread](#create-thread)
     - [Create Thread and Run](#create-thread-and-run)
-      - [Streaming](#create-thread-and-run-streaming) :new:
+      - [Streaming](#create-thread-and-run-streaming) :warning: :construction:
     - [Retrieve Thread](#retrieve-thread)
     - [Modify Thread](#modify-thread)
     - [Delete Thread](#delete-thread)
@@ -86,29 +86,29 @@ The recommended installation method is though the unity package manager and [Ope
     - [Thread Runs](#thread-runs)
       - [List Runs](#list-thread-runs)
       - [Create Run](#create-thread-run)
-        - [Streaming](#create-thread-run-streaming) :new:
+        - [Streaming](#create-thread-run-streaming) :warning: :construction:
       - [Retrieve Run](#retrieve-thread-run)
       - [Modify Run](#modify-thread-run)
       - [Submit Tool Outputs to Run](#thread-submit-tool-outputs-to-run)
       - [List Run Steps](#list-thread-run-steps)
       - [Retrieve Run Step](#retrieve-thread-run-step)
       - [Cancel Run](#cancel-thread-run)
-  - [Vector Stores](#vector-stores) :new:
-    - [List Vector Stores](#list-vector-stores) :new:
-    - [Create Vector Store](#create-vector-store) :new:
-    - [Retrieve Vector Store](#retrieve-vector-store) :new:
-    - [Modify Vector Store](#modify-vector-store) :new:
-    - [Delete Vector Store](#delete-vector-store) :new:
-    - [Vector Store Files](#vector-store-files) :new:
-      - [List Vector Store Files](#list-vector-store-files) :new:
-      - [Create Vector Store File](#create-vector-store-file) :new:
-      - [Retrieve Vector Store File](#retrieve-vector-store-file) :new:
-      - [Delete Vector Store File](#delete-vector-store-file) :new:
-    - [Vector Store File Batches](#vector-store-file-batches) :new:
-      - [Create Vector Store File Batch](#create-vector-store-file-batch) :new:
-      - [Retrieve Vector Store File Batch](#retrieve-vector-store-file-batch) :new:
-      - [List Files In Vector Store Batch](#list-files-in-vector-store-batch) :new:
-      - [Cancel Vector Store File Batch](#cancel-vector-store-file-batch) :new:
+  - [Vector Stores](#vector-stores)
+    - [List Vector Stores](#list-vector-stores)
+    - [Create Vector Store](#create-vector-store)
+    - [Retrieve Vector Store](#retrieve-vector-store)
+    - [Modify Vector Store](#modify-vector-store)
+    - [Delete Vector Store](#delete-vector-store)
+    - [Vector Store Files](#vector-store-files)
+      - [List Vector Store Files](#list-vector-store-files)
+      - [Create Vector Store File](#create-vector-store-file)
+      - [Retrieve Vector Store File](#retrieve-vector-store-file)
+      - [Delete Vector Store File](#delete-vector-store-file)
+    - [Vector Store File Batches](#vector-store-file-batches)
+      - [Create Vector Store File Batch](#create-vector-store-file-batch)
+      - [Retrieve Vector Store File Batch](#retrieve-vector-store-file-batch)
+      - [List Files In Vector Store Batch](#list-files-in-vector-store-batch)
+      - [Cancel Vector Store File Batch](#cancel-vector-store-file-batch)
 - [Chat](#chat)
   - [Chat Completions](#chat-completions)
   - [Streaming](#chat-streaming)
@@ -136,11 +136,11 @@ The recommended installation method is though the unity package manager and [Ope
   - [Retrieve Fine Tune Job Info](#retrieve-fine-tune-job-info)
   - [Cancel Fine Tune Job](#cancel-fine-tune-job)
   - [List Fine Tune Job Events](#list-fine-tune-job-events)
-- [Batches](#batches) :new:
-  - [List Batches](#list-batches) :new:
-  - [Create Batch](#create-batch) :new:
-  - [Retrieve Batch](#retrieve-batch) :new:
-  - [Cancel Batch](#cancel-batch) :new:
+- [Batches](#batches)
+  - [List Batches](#list-batches)
+  - [Create Batch](#create-batch)
+  - [Retrieve Batch](#retrieve-batch)
+  - [Cancel Batch](#cancel-batch)
 - [Embeddings](#embeddings)
   - [Create Embedding](#create-embeddings)
 - [Moderations](#moderations)
@@ -479,7 +479,7 @@ Assert.IsTrue(isDeleted);
 #### [Assistant Streaming](https://platform.openai.com/docs/api-reference/assistants-streaming)
 
 > [!NOTE]
-> Assistant stream events can be easily added to existing thread calls by passing `Action<IServerSentEvent> streamEventHandler` callback to any existing method that supports streaming.
+> Assistant stream events can be easily added to existing thread calls by passing `Func<IServerSentEvent, Task> streamEventHandler` callback to any existing method that supports streaming.
 
 #### [Threads](https://platform.openai.com/docs/api-reference/threads)
 
@@ -529,7 +529,7 @@ var tools = new List<Tool>
 var assistantRequest = new CreateAssistantRequest(tools: tools, instructions: "You are a helpful weather assistant. Use the appropriate unit based on geographical location.");
 var assistant = await api.AssistantsEndpoint.CreateAssistantAsync(assistantRequest);
 ThreadResponse thread = null;
-async void StreamEventHandler(IServerSentEvent streamEvent)
+async Task StreamEventHandler(IServerSentEvent streamEvent)
 {
     switch (streamEvent)
     {
@@ -723,9 +723,10 @@ var assistant = await api.AssistantsEndpoint.CreateAssistantAsync(
         responseFormat: ChatResponseFormat.Json));
 var thread = await api.ThreadsEndpoint.CreateThreadAsync();
 var message = await thread.CreateMessageAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?");
-var run = await thread.CreateRunAsync(assistant, streamEvent =>
+var run = await thread.CreateRunAsync(assistant, async streamEvent =>
 {
     Debug.Log(streamEvent.ToJsonString());
+    await Task.CompletedTask;
 });
 var messages = await thread.ListMessagesAsync();
 
@@ -1057,9 +1058,10 @@ var messages = new List<Message>
     new Message(Role.User, "Where was it played?"),
 };
 var chatRequest = new ChatRequest(messages);
-var response = await api.ChatEndpoint.StreamCompletionAsync(chatRequest, partialResponse =>
+var response = await api.ChatEndpoint.StreamCompletionAsync(chatRequest, async partialResponse =>
 {
     Debug.Log(partialResponse.FirstChoice.Delta.ToString());
+    await Task.Completed;
 });
 var choice = response.FirstChoice;
 Debug.Log($"[{choice.Index}] {choice.Message.Role}: {choice.Message} | Finish Reason: {choice.FinishReason}");

--- a/OpenAI/Packages/com.openai.unity/Runtime/Assistants/AssistantExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Assistants/AssistantExtensions.cs
@@ -64,15 +64,23 @@ namespace OpenAI.Assistants
             return deleteTasks.TrueForAll(task => task.Result);
         }
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> CreateThreadAndRunAsync(this AssistantResponse assistant, CreateThreadRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await CreateThreadAndRunAsync(assistant, request, streamEventHandler == null ? null : async serverSentEvent =>
+            {
+                streamEventHandler.Invoke(serverSentEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// Create a thread and run it.
         /// </summary>
         /// <param name="assistant"><see cref="AssistantResponse"/>.</param>
         /// <param name="request">Optional, <see cref="CreateThreadRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> CreateThreadAndRunAsync(this AssistantResponse assistant, CreateThreadRequest request = null, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> CreateThreadAndRunAsync(this AssistantResponse assistant, CreateThreadRequest request = null, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await assistant.Client.ThreadsEndpoint.CreateThreadAndRunAsync(new CreateThreadAndRunRequest(assistant.Id, createThreadRequest: request), streamEventHandler, cancellationToken);
 
         #region Tools

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatResponse.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/ChatResponse.cs
@@ -105,7 +105,14 @@ namespace OpenAI.Chat
         {
             if (other is null) { return; }
 
-            if (!string.IsNullOrWhiteSpace(other.Id))
+            if (!string.IsNullOrWhiteSpace(Id))
+            {
+                if (Id != other.Id)
+                {
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
+                }
+            }
+            else
             {
                 Id = other.Id;
             }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Common/Error.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Common/Error.cs
@@ -1,6 +1,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Newtonsoft.Json;
+using System;
 using System.Text;
 using UnityEngine.Scripting;
 using Utilities.WebRequestRest.Interfaces;
@@ -24,6 +25,14 @@ namespace OpenAI
             Parameter = parameter;
             Type = type;
             Line = line;
+        }
+
+        [Preserve]
+        internal Error(Exception e)
+        {
+            Type = e.GetType().Name;
+            Message = e.Message;
+            Exception = e;
         }
 
         /// <summary>
@@ -64,6 +73,10 @@ namespace OpenAI
         [Preserve]
         [JsonIgnore]
         public string Object => "error";
+
+        [Preserve]
+        [JsonIgnore]
+        public Exception Exception { get; }
 
         [Preserve]
         public override string ToString()

--- a/OpenAI/Packages/com.openai.unity/Runtime/Common/Function.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Common/Function.cs
@@ -161,7 +161,7 @@ namespace OpenAI
         /// The optional description of the function.
         /// </summary>
         [Preserve]
-        [JsonProperty("description")]
+        [JsonProperty("description", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Description { get; private set; }
 
         private string parametersString;
@@ -173,7 +173,7 @@ namespace OpenAI
         /// Describe the parameters that the model should generate in JSON schema format (json-schema.org).
         /// </summary>
         [Preserve]
-        [JsonProperty("parameters")]
+        [JsonProperty("parameters", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public JToken Parameters
         {
             get
@@ -197,7 +197,7 @@ namespace OpenAI
         /// The arguments to use when calling the function.
         /// </summary>
         [Preserve]
-        [JsonProperty("arguments")]
+        [JsonProperty("arguments", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public JToken Arguments
         {
             get

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/CodeInterpreter.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/CodeInterpreter.cs
@@ -23,7 +23,7 @@ namespace OpenAI.Threads
         /// The input to the Code Interpreter tool call.
         /// </summary>
         [Preserve]
-        [JsonProperty("input")]
+        [JsonProperty("input", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Input { get; private set; }
 
         private List<CodeInterpreterOutputs> outputs;
@@ -34,7 +34,7 @@ namespace OpenAI.Threads
         /// Each of these are represented by a different object type.
         /// </summary>
         [Preserve]
-        [JsonProperty("outputs")]
+        [JsonProperty("outputs", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IReadOnlyList<CodeInterpreterOutputs> Outputs => outputs;
 
         internal void AppendFrom(CodeInterpreter other)

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/CodeInterpreterOutputs.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/CodeInterpreterOutputs.cs
@@ -38,7 +38,7 @@ namespace OpenAI.Threads
         /// Text output from the Code Interpreter tool call as part of a run step.
         /// </summary>
         [Preserve]
-        [JsonProperty("logs")]
+        [JsonProperty("logs", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Logs { get; private set; }
 
         /// <summary>

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/FunctionCall.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/FunctionCall.cs
@@ -31,14 +31,14 @@ namespace OpenAI.Threads
         /// The arguments that the model expects you to pass to the function.
         /// </summary>
         [Preserve]
-        [JsonProperty("arguments")]
+        [JsonProperty("arguments", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Arguments { get; private set; }
 
         /// <summary>
         /// The output of the function. This will be null if the outputs have not been submitted yet.
         /// </summary>
         [Preserve]
-        [JsonProperty("output")]
+        [JsonProperty("output", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Output { get; private set; }
 
         internal void AppendFrom(FunctionCall other)

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/MessageResponse.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/MessageResponse.cs
@@ -217,7 +217,7 @@ namespace OpenAI.Threads
             {
                 if (Id != other.Id)
                 {
-                    throw new InvalidOperationException("Attempting to append a different object than the original!");
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
                 }
             }
             else

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/RunResponse.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/RunResponse.cs
@@ -344,7 +344,7 @@ namespace OpenAI.Threads
             {
                 if (Id != other.Id)
                 {
-                    throw new InvalidOperationException("Attempting to append a different object than the original!");
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
                 }
             }
             else

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/RunStepResponse.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/RunStepResponse.cs
@@ -229,7 +229,7 @@ namespace OpenAI.Threads
             {
                 if (Id != other.Id)
                 {
-                    throw new InvalidOperationException("Attempting to append a different object than the original!");
+                    throw new InvalidOperationException($"Attempting to append a different object than the original! {Id} != {other.Id}");
                 }
             }
             else

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadExtensions.cs
@@ -178,26 +178,42 @@ namespace OpenAI.Threads
 
         #region Runs
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, CreateRunRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await thread.CreateRunAsync(request, async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// Create a run.
         /// </summary>
         /// <param name="thread"><see cref="ThreadResponse"/>.</param>
         /// <param name="request"><see cref="CreateRunRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, CreateRunRequest request = null, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, CreateRunRequest request = null, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await thread.Client.ThreadsEndpoint.CreateRunAsync(thread, request, streamEventHandler, cancellationToken);
+
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, AssistantResponse assistant, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await thread.CreateRunAsync(assistant, async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
 
         /// <summary>
         /// Create a run.
         /// </summary>
         /// <param name="thread"><see cref="ThreadResponse"/>.</param>
         /// <param name="assistant">The <see cref="AssistantResponse"/> to use for the run.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, AssistantResponse assistant, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> CreateRunAsync(this ThreadResponse thread, AssistantResponse assistant, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
         {
             var request = new CreateRunRequest(
                 assistant,
@@ -287,6 +303,14 @@ namespace OpenAI.Threads
             return result;
         }
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, SubmitToolOutputsRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await run.SubmitToolOutputsAsync(request, async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// When a run has the status: "requires_action" and required_action.type is submit_tool_outputs,
         /// this endpoint can be used to submit the outputs from the tool calls once they're all completed.
@@ -294,11 +318,19 @@ namespace OpenAI.Threads
         /// </summary>
         /// <param name="run"><see cref="RunResponse"/> to submit outputs for.</param>
         /// <param name="request"><see cref="SubmitToolOutputsRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, SubmitToolOutputsRequest request, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, SubmitToolOutputsRequest request, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await run.Client.ThreadsEndpoint.SubmitToolOutputsAsync(run.ThreadId, run.Id, request, streamEventHandler, cancellationToken);
+
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, IEnumerable<ToolOutput> outputs, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await run.SubmitToolOutputsAsync(new SubmitToolOutputsRequest(outputs), async streamEvent =>
+            {
+                streamEventHandler?.Invoke(streamEvent);
+                await Task.CompletedTask;
+            }, cancellationToken);
 
         /// <summary>
         /// When a run has the status: "requires_action" and required_action.type is submit_tool_outputs,
@@ -307,10 +339,10 @@ namespace OpenAI.Threads
         /// </summary>
         /// <param name="run"><see cref="RunResponse"/> to submit outputs for.</param>
         /// <param name="outputs"><see cref="ToolOutput"/>s</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, IEnumerable<ToolOutput> outputs, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public static async Task<RunResponse> SubmitToolOutputsAsync(this RunResponse run, IEnumerable<ToolOutput> outputs, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
             => await run.SubmitToolOutputsAsync(new SubmitToolOutputsRequest(outputs), streamEventHandler, cancellationToken);
 
         /// <summary>

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadsEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadsEndpoint.cs
@@ -194,15 +194,23 @@ namespace OpenAI.Threads
             return response.Deserialize<ListResponse<RunResponse>>(client);
         }
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public async Task<RunResponse> CreateRunAsync(string threadId, CreateRunRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await CreateRunAsync(threadId, request, streamEventHandler == null ? null : serverSentEvent =>
+            {
+                streamEventHandler.Invoke(serverSentEvent);
+                return Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// Create a run.
         /// </summary>
         /// <param name="threadId">The id of the thread to run.</param>
         /// <param name="request"><see cref="CreateRunRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public async Task<RunResponse> CreateRunAsync(string threadId, CreateRunRequest request = null, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public async Task<RunResponse> CreateRunAsync(string threadId, CreateRunRequest request = null, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.AssistantId))
             {
@@ -224,14 +232,22 @@ namespace OpenAI.Threads
             return response.Deserialize<RunResponse>(client);
         }
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public async Task<RunResponse> CreateThreadAndRunAsync(CreateThreadAndRunRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await CreateThreadAndRunAsync(request, streamEventHandler == null ? null : serverSentEvent =>
+            {
+                streamEventHandler.Invoke(serverSentEvent);
+                return Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// Create a thread and run it in one request.
         /// </summary>
         /// <param name="request"><see cref="CreateThreadAndRunRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public async Task<RunResponse> CreateThreadAndRunAsync(CreateThreadAndRunRequest request = null, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public async Task<RunResponse> CreateThreadAndRunAsync(CreateThreadAndRunRequest request = null, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
         {
             if (request == null || string.IsNullOrWhiteSpace(request.AssistantId))
             {
@@ -288,6 +304,14 @@ namespace OpenAI.Threads
             return response.Deserialize<RunResponse>(client);
         }
 
+        [Obsolete("use new overload with Func<IServerSentEvent, Task> instead.")]
+        public async Task<RunResponse> SubmitToolOutputsAsync(string threadId, string runId, SubmitToolOutputsRequest request, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+            => await SubmitToolOutputsAsync(threadId, runId, request, streamEventHandler == null ? null : serverSentEvent =>
+            {
+                streamEventHandler.Invoke(serverSentEvent);
+                return Task.CompletedTask;
+            }, cancellationToken);
+
         /// <summary>
         /// When a run has the status: "requires_action" and required_action.type is submit_tool_outputs,
         /// this endpoint can be used to submit the outputs from the tool calls once they're all completed.
@@ -296,10 +320,10 @@ namespace OpenAI.Threads
         /// <param name="threadId">The id of the thread to which this run belongs.</param>
         /// <param name="runId">The id of the run that requires the tool output submission.</param>
         /// <param name="request"><see cref="SubmitToolOutputsRequest"/>.</param>
-        /// <param name="streamEventHandler">Optional, <see cref="Action{IStreamEvent}"/> stream callback handler.</param>
+        /// <param name="streamEventHandler">Optional, <see cref="Func{IServerSentEvent, Task}"/> stream callback handler.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="RunResponse"/>.</returns>
-        public async Task<RunResponse> SubmitToolOutputsAsync(string threadId, string runId, SubmitToolOutputsRequest request, Action<IServerSentEvent> streamEventHandler = null, CancellationToken cancellationToken = default)
+        public async Task<RunResponse> SubmitToolOutputsAsync(string threadId, string runId, SubmitToolOutputsRequest request, Func<IServerSentEvent, Task> streamEventHandler = null, CancellationToken cancellationToken = default)
         {
             request.Stream = streamEventHandler != null;
             var payload = JsonConvert.SerializeObject(request, OpenAIClient.JsonSerializationOptions);
@@ -411,19 +435,20 @@ namespace OpenAI.Threads
 
         #endregion Files (Obsolete)
 
-        private async Task<RunResponse> StreamRunAsync(string endpoint, string payload, Action<IServerSentEvent> streamEventHandler, CancellationToken cancellationToken = default)
+        private async Task<RunResponse> StreamRunAsync(string endpoint, string payload, Func<IServerSentEvent, Task> streamEventHandler, CancellationToken cancellationToken = default)
         {
             RunResponse run = null;
             RunStepResponse runStep = null;
             MessageResponse message = null;
-            var response = await Rest.PostAsync(endpoint, payload, (sseResponse, ssEvent) =>
+
+            var response = await Rest.PostAsync(endpoint, payload, async (sseResponse, ssEvent) =>
             {
                 try
                 {
                     switch (ssEvent.Value.Value<string>())
                     {
                         case "thread.created":
-                            streamEventHandler?.Invoke(sseResponse.Deserialize<ThreadResponse>(client));
+                            await streamEventHandler.Invoke(sseResponse.Deserialize<ThreadResponse>(client));
                             return;
                         case "thread.run.created":
                         case "thread.run.queued":
@@ -446,7 +471,7 @@ namespace OpenAI.Threads
                                 run.AppendFrom(partialRun);
                             }
 
-                            streamEventHandler?.Invoke(run);
+                            await streamEventHandler.Invoke(run);
                             return;
                         case "thread.run.step.created":
                         case "thread.run.step.in_progress":
@@ -457,7 +482,8 @@ namespace OpenAI.Threads
                         case "thread.run.step.expired":
                             var partialRunStep = sseResponse.Deserialize<RunStepResponse>(client);
 
-                            if (runStep == null)
+                            if (runStep == null ||
+                                runStep.Id != partialRunStep.Id)
                             {
                                 runStep = partialRunStep;
                             }
@@ -466,7 +492,7 @@ namespace OpenAI.Threads
                                 runStep.AppendFrom(partialRunStep);
                             }
 
-                            streamEventHandler?.Invoke(runStep);
+                            await streamEventHandler.Invoke(runStep);
                             return;
                         case "thread.message.created":
                         case "thread.message.in_progress":
@@ -475,7 +501,8 @@ namespace OpenAI.Threads
                         case "thread.message.incomplete":
                             var partialMessage = sseResponse.Deserialize<MessageResponse>(client);
 
-                            if (message == null)
+                            if (message == null ||
+                                message.Id != partialMessage.Id)
                             {
                                 message = partialMessage;
                             }
@@ -484,14 +511,14 @@ namespace OpenAI.Threads
                                 message.AppendFrom(partialMessage);
                             }
 
-                            streamEventHandler?.Invoke(message);
+                            await streamEventHandler.Invoke(message);
                             return;
                         case "error":
-                            streamEventHandler?.Invoke(sseResponse.Deserialize<Error>(client));
+                            await streamEventHandler.Invoke(sseResponse.Deserialize<Error>(client));
                             return;
                         default:
                             // if not properly handled raise it up to caller to deal with it themselves.
-                            streamEventHandler.Invoke(ssEvent);
+                            await streamEventHandler.Invoke(ssEvent);
                             return;
                     }
                 }
@@ -502,6 +529,7 @@ namespace OpenAI.Threads
             }, new RestParameters(client.DefaultRequestHeaders), cancellationToken);
             response.Validate(EnableDebug);
             if (run == null) { return null; }
+            run = await run.WaitForStatusChangeAsync(timeout: -1, cancellationToken: cancellationToken);
             run.SetResponseData(response, client);
             return run;
         }

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
@@ -391,7 +391,6 @@ namespace OpenAI.Tests
                     catch (Exception e)
                     {
                         Debug.LogException(e);
-                        throw;
                     }
                 }
 

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
@@ -315,10 +315,6 @@ namespace OpenAI.Tests
                         case Error errorEvent:
                             Assert.NotNull(errorEvent);
                             break;
-                            //default:
-                            // handle event not already processed by library
-                            // var @event = JsonSerializer.Deserialize<T>(streamEvent.ToJsonString());
-                            //break;
                     }
 
                     await Task.CompletedTask;

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
@@ -274,7 +274,7 @@ namespace OpenAI.Tests
                 var message = await thread.CreateMessageAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?");
                 Assert.NotNull(message);
 
-                var run = await thread.CreateRunAsync(assistant, streamEvent =>
+                var run = await thread.CreateRunAsync(assistant, async streamEvent =>
                 {
                     Debug.Log(streamEvent.ToJsonString());
 
@@ -320,6 +320,8 @@ namespace OpenAI.Tests
                             // var @event = JsonSerializer.Deserialize<T>(streamEvent.ToJsonString());
                             //break;
                     }
+
+                    await Task.CompletedTask;
                 });
 
                 Assert.IsNotNull(run);
@@ -363,7 +365,7 @@ namespace OpenAI.Tests
 
             try
             {
-                async void StreamEventHandler(IServerSentEvent streamEvent)
+                async Task StreamEventHandler(IServerSentEvent streamEvent)
                 {
                     try
                     {
@@ -393,6 +395,7 @@ namespace OpenAI.Tests
                     catch (Exception e)
                     {
                         Debug.LogException(e);
+                        throw;
                     }
                 }
 
@@ -499,9 +502,10 @@ namespace OpenAI.Tests
             try
             {
                 var run = await assistant.CreateThreadAndRunAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?",
-                    @event =>
+                    async @event =>
                     {
                         Debug.Log(@event.ToJsonString());
+                        await Task.CompletedTask;
                     });
                 Assert.IsNotNull(run);
                 thread = await run.GetThreadAsync();
@@ -535,7 +539,81 @@ namespace OpenAI.Tests
         }
 
         [Test]
-        public async Task Test_04_03_CreateThreadAndRun_SubmitToolOutput()
+        public async Task Test_04_03_CreateThreadAndRun_Streaming_ToolCalls()
+        {
+            Assert.NotNull(OpenAIClient.ThreadsEndpoint);
+            var tools = Tool.GetAllAvailableTools();
+            var assistantRequest = new CreateAssistantRequest(
+                instructions: "You are a helpful assistant.",
+                tools: tools);
+            var assistant = await OpenAIClient.AssistantsEndpoint.CreateAssistantAsync(assistantRequest);
+            Assert.IsNotNull(assistant);
+            ThreadResponse thread = null;
+            // check if any exceptions thrown in stream event handler
+            var exceptionThrown = false;
+            var hasInvokedCallback = false;
+
+            try
+            {
+                async Task StreamEventHandler(IServerSentEvent streamEvent)
+                {
+                    hasInvokedCallback = true;
+                    Debug.Log($"{streamEvent.ToJsonString()}");
+
+                    try
+                    {
+                        switch (streamEvent)
+                        {
+                            case ThreadResponse threadResponse:
+                                thread = threadResponse;
+                                break;
+                            case RunResponse runResponse:
+                                if (runResponse.Status == RunStatus.RequiresAction)
+                                {
+                                    var toolOutputs = await assistant.GetToolOutputsAsync(runResponse);
+                                    var toolRun = await runResponse.SubmitToolOutputsAsync(toolOutputs, StreamEventHandler);
+                                    Assert.NotNull(toolRun);
+                                    Assert.IsTrue(toolRun.Status == RunStatus.Completed);
+                                }
+
+                                break;
+                            case Error errorResponse:
+                                throw errorResponse.Exception ?? new Exception(errorResponse.Message);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogError(e);
+                        exceptionThrown = true;
+                    }
+                }
+
+                var run = await assistant.CreateThreadAndRunAsync("What date is it?", StreamEventHandler);
+                Assert.IsTrue(hasInvokedCallback);
+                Assert.NotNull(thread);
+                Assert.IsNotNull(run);
+                Assert.IsFalse(exceptionThrown);
+                Assert.IsTrue(run.Status == RunStatus.Completed);
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                throw;
+            }
+            finally
+            {
+                await assistant.DeleteAsync(deleteToolResources: thread == null);
+
+                if (thread != null)
+                {
+                    var isDeleted = await thread.DeleteAsync(deleteToolResources: true);
+                    Assert.IsTrue(isDeleted);
+                }
+            }
+        }
+
+        [Test]
+        public async Task Test_04_04_CreateThreadAndRun_SubmitToolOutput()
         {
             var tools = new List<Tool>
             {

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_03_Threads.cs
@@ -497,9 +497,9 @@ namespace OpenAI.Tests
             try
             {
                 var run = await assistant.CreateThreadAndRunAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?",
-                    async @event =>
+                    async streamEvent =>
                     {
-                        Debug.Log(@event.ToJsonString());
+                        Debug.Log(streamEvent.ToJsonString());
                         await Task.CompletedTask;
                     });
                 Assert.IsNotNull(run);

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_04_Chat.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_04_Chat.cs
@@ -116,7 +116,10 @@ namespace OpenAI.Tests
                 Debug.Log($"{message.Role}: {message.Content}");
             }
 
-            var tools = Tool.GetAllAvailableTools(false, forceUpdate: true, clearCache: true);
+            var tools = new List<Tool>
+            {
+                Tool.GetOrCreateTool(typeof(WeatherService), nameof(WeatherService.GetCurrentWeatherAsync))
+            };
             var chatRequest = new ChatRequest(messages, tools: tools, toolChoice: "none");
             var response = await OpenAIClient.ChatEndpoint.GetCompletionAsync(chatRequest);
             Assert.IsNotNull(response);
@@ -183,7 +186,10 @@ namespace OpenAI.Tests
                 Debug.Log($"{message.Role}: {message.Content}");
             }
 
-            var tools = Tool.GetAllAvailableTools(false);
+            var tools = new List<Tool>
+            {
+                Tool.GetOrCreateTool(typeof(WeatherService), nameof(WeatherService.GetCurrentWeatherAsync))
+            };
             var chatRequest = new ChatRequest(messages, tools: tools, toolChoice: "none");
             var response = await OpenAIClient.ChatEndpoint.StreamCompletionAsync(chatRequest, partialResponse =>
             {

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity Game Engine to use GPT-4, GPT-3.5, GPT-3 and Dall-E though their RESTful API (currently in beta).\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "8.0.3",
+  "version": "8.1.0",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",
@@ -17,8 +17,8 @@
     "url": "https://github.com/StephenHodgson"
   },
   "dependencies": {
-    "com.utilities.rest": "3.1.2",
-    "com.utilities.encoder.wav": "1.1.5"
+    "com.utilities.rest": "3.2.0",
+    "com.utilities.encoder.wav": "1.2.1"
   },
   "samples": [
     {

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The recommended installation method is though the unity package manager and [Ope
 
 ### Table of Contents
 
-- [Authentication](#authentication) :new: :warning: :construction:
+- [Authentication](#authentication)
 - [Azure OpenAI](#azure-openai)
   - [Azure Active Directory Authentication](#azure-active-directory-authentication)
 - [OpenAI API Proxy](#openai-api-proxy)
@@ -64,17 +64,17 @@ The recommended installation method is though the unity package manager and [Ope
   - [List Models](#list-models)
   - [Retrieve Models](#retrieve-model)
   - [Delete Fine Tuned Model](#delete-fine-tuned-model)
-- [Assistants](#assistants) :new: :warning: :construction:
+- [Assistants](#assistants) :warning: :construction:
   - [List Assistants](#list-assistants)
   - [Create Assistant](#create-assistant)
   - [Retrieve Assistant](#retrieve-assistant)
   - [Modify Assistant](#modify-assistant)
   - [Delete Assistant](#delete-assistant)
-  - [Assistant Streaming](#assistant-streaming) :new:
-  - [Threads](#threads) :new: :warning: :construction:
+  - [Assistant Streaming](#assistant-streaming) :warning: :construction:
+  - [Threads](#threads) :warning: :construction:
     - [Create Thread](#create-thread)
     - [Create Thread and Run](#create-thread-and-run)
-      - [Streaming](#create-thread-and-run-streaming) :new:
+      - [Streaming](#create-thread-and-run-streaming) :warning: :construction:
     - [Retrieve Thread](#retrieve-thread)
     - [Modify Thread](#modify-thread)
     - [Delete Thread](#delete-thread)
@@ -86,29 +86,29 @@ The recommended installation method is though the unity package manager and [Ope
     - [Thread Runs](#thread-runs)
       - [List Runs](#list-thread-runs)
       - [Create Run](#create-thread-run)
-        - [Streaming](#create-thread-run-streaming) :new:
+        - [Streaming](#create-thread-run-streaming) :warning: :construction:
       - [Retrieve Run](#retrieve-thread-run)
       - [Modify Run](#modify-thread-run)
       - [Submit Tool Outputs to Run](#thread-submit-tool-outputs-to-run)
       - [List Run Steps](#list-thread-run-steps)
       - [Retrieve Run Step](#retrieve-thread-run-step)
       - [Cancel Run](#cancel-thread-run)
-  - [Vector Stores](#vector-stores) :new:
-    - [List Vector Stores](#list-vector-stores) :new:
-    - [Create Vector Store](#create-vector-store) :new:
-    - [Retrieve Vector Store](#retrieve-vector-store) :new:
-    - [Modify Vector Store](#modify-vector-store) :new:
-    - [Delete Vector Store](#delete-vector-store) :new:
-    - [Vector Store Files](#vector-store-files) :new:
-      - [List Vector Store Files](#list-vector-store-files) :new:
-      - [Create Vector Store File](#create-vector-store-file) :new:
-      - [Retrieve Vector Store File](#retrieve-vector-store-file) :new:
-      - [Delete Vector Store File](#delete-vector-store-file) :new:
-    - [Vector Store File Batches](#vector-store-file-batches) :new:
-      - [Create Vector Store File Batch](#create-vector-store-file-batch) :new:
-      - [Retrieve Vector Store File Batch](#retrieve-vector-store-file-batch) :new:
-      - [List Files In Vector Store Batch](#list-files-in-vector-store-batch) :new:
-      - [Cancel Vector Store File Batch](#cancel-vector-store-file-batch) :new:
+  - [Vector Stores](#vector-stores)
+    - [List Vector Stores](#list-vector-stores)
+    - [Create Vector Store](#create-vector-store)
+    - [Retrieve Vector Store](#retrieve-vector-store)
+    - [Modify Vector Store](#modify-vector-store)
+    - [Delete Vector Store](#delete-vector-store)
+    - [Vector Store Files](#vector-store-files)
+      - [List Vector Store Files](#list-vector-store-files)
+      - [Create Vector Store File](#create-vector-store-file)
+      - [Retrieve Vector Store File](#retrieve-vector-store-file)
+      - [Delete Vector Store File](#delete-vector-store-file)
+    - [Vector Store File Batches](#vector-store-file-batches)
+      - [Create Vector Store File Batch](#create-vector-store-file-batch)
+      - [Retrieve Vector Store File Batch](#retrieve-vector-store-file-batch)
+      - [List Files In Vector Store Batch](#list-files-in-vector-store-batch)
+      - [Cancel Vector Store File Batch](#cancel-vector-store-file-batch)
 - [Chat](#chat)
   - [Chat Completions](#chat-completions)
   - [Streaming](#chat-streaming)
@@ -136,11 +136,11 @@ The recommended installation method is though the unity package manager and [Ope
   - [Retrieve Fine Tune Job Info](#retrieve-fine-tune-job-info)
   - [Cancel Fine Tune Job](#cancel-fine-tune-job)
   - [List Fine Tune Job Events](#list-fine-tune-job-events)
-- [Batches](#batches) :new:
-  - [List Batches](#list-batches) :new:
-  - [Create Batch](#create-batch) :new:
-  - [Retrieve Batch](#retrieve-batch) :new:
-  - [Cancel Batch](#cancel-batch) :new:
+- [Batches](#batches)
+  - [List Batches](#list-batches)
+  - [Create Batch](#create-batch)
+  - [Retrieve Batch](#retrieve-batch)
+  - [Cancel Batch](#cancel-batch)
 - [Embeddings](#embeddings)
   - [Create Embedding](#create-embeddings)
 - [Moderations](#moderations)
@@ -479,7 +479,7 @@ Assert.IsTrue(isDeleted);
 #### [Assistant Streaming](https://platform.openai.com/docs/api-reference/assistants-streaming)
 
 > [!NOTE]
-> Assistant stream events can be easily added to existing thread calls by passing `Action<IServerSentEvent> streamEventHandler` callback to any existing method that supports streaming.
+> Assistant stream events can be easily added to existing thread calls by passing `Func<IServerSentEvent, Task> streamEventHandler` callback to any existing method that supports streaming.
 
 #### [Threads](https://platform.openai.com/docs/api-reference/threads)
 
@@ -529,7 +529,7 @@ var tools = new List<Tool>
 var assistantRequest = new CreateAssistantRequest(tools: tools, instructions: "You are a helpful weather assistant. Use the appropriate unit based on geographical location.");
 var assistant = await api.AssistantsEndpoint.CreateAssistantAsync(assistantRequest);
 ThreadResponse thread = null;
-async void StreamEventHandler(IServerSentEvent streamEvent)
+async Task StreamEventHandler(IServerSentEvent streamEvent)
 {
     switch (streamEvent)
     {
@@ -723,9 +723,10 @@ var assistant = await api.AssistantsEndpoint.CreateAssistantAsync(
         responseFormat: ChatResponseFormat.Json));
 var thread = await api.ThreadsEndpoint.CreateThreadAsync();
 var message = await thread.CreateMessageAsync("I need to solve the equation `3x + 11 = 14`. Can you help me?");
-var run = await thread.CreateRunAsync(assistant, streamEvent =>
+var run = await thread.CreateRunAsync(assistant, async streamEvent =>
 {
     Debug.Log(streamEvent.ToJsonString());
+    await Task.CompletedTask;
 });
 var messages = await thread.ListMessagesAsync();
 
@@ -1057,9 +1058,10 @@ var messages = new List<Message>
     new Message(Role.User, "Where was it played?"),
 };
 var chatRequest = new ChatRequest(messages);
-var response = await api.ChatEndpoint.StreamCompletionAsync(chatRequest, partialResponse =>
+var response = await api.ChatEndpoint.StreamCompletionAsync(chatRequest, async partialResponse =>
 {
     Debug.Log(partialResponse.FirstChoice.Delta.ToString());
+    await Task.CompletedTask;
 });
 var choice = response.FirstChoice;
 Debug.Log($"[{choice.Index}] {choice.Message.Role}: {choice.Message} | Finish Reason: {choice.FinishReason}");


### PR DESCRIPTION
- Fixed streaming event race conditions where the subscriber to the stream would finish before steam events were executed
- Refactored streaming events callbacks from `Action<IServerSentEvent>` to `Func<IServerSentEvent, Task>`
- Added `Exception` data to `OpenAI.Error` response
- Added `ChatEndpoint.StreamCompletionAsync` with `Func<ChatResponse, Task>` overload