### PR TITLE
Add non-server-VAD use case to VoiceActivityDetectionSettings

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Realtime/VoiceActivityDetectionSettings.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Realtime/VoiceActivityDetectionSettings.cs
@@ -23,6 +23,9 @@ namespace OpenAI.Realtime
                     PrefixPadding = prefixPadding;
                     SilenceDuration = silenceDuration;
                     break;
+                case TurnDetectionType.Disabled:
+                    Type = TurnDetectionType.Disabled;
+                    break;
             }
         }
 


### PR DESCRIPTION
hi, i'm new to your great project. 

I have tried to use it on unity to connect to the openai realtime.
I just found that I want to turn off the server side voice activity detection(VAD) but
there is no constructor for disable case. 

This PR is just show you where the code is and carefully suggest you to take a look at non-server-VAD use case. 
(Maybe this should go to issues?)

Thanks to your great code!