### PR TITLE
Fix: Sanitize non-standard voice names to prevent caching errors

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Audio/AudioEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Audio/AudioEndpoint.cs
@@ -68,7 +68,23 @@ namespace OpenAI.Audio
 
             lock (mutex)
             {
-                clipName = $"{request.Voice}-{DateTime.UtcNow:yyyyMMddThhmmssfffff}.{ext}";
+                
+                // Sanitize the voice name to ensure it's a valid filename
+                string safeVoiceName = request.Voice;
+                if (string.IsNullOrEmpty(safeVoiceName))
+                {
+                    safeVoiceName = "unnamed";
+                }
+                else
+                {
+                    // Replace invalid characters with underscores
+                    foreach (char c in Path.GetInvalidFileNameChars())
+                    {
+                        safeVoiceName = safeVoiceName.Replace(c, '_');
+                    }
+                }
+
+                clipName = $"{safeVoiceName}-{DateTime.UtcNow:yyyyMMddThhmmssfffff}.{ext}";
             }
 
             Rest.TryGetDownloadCacheItem(clipName, out var cachedPath);


### PR DESCRIPTION
### What happened?

When using third-party TTS providers like SiliconFlow, some voice models (e.g., CosyVoice) provide voice names that contain characters invalid for file paths.

For example, a voice name might be FunAudioLLM/CosyVoice2-0.5B:diana.

The application was using this name directly to create a local cache file. Since characters like / and : are not allowed in filenames, this resulted in a TextToSpeech error: Could not find a part of the path... and the audio caching would fail.

### Error Screenshot:

![Screenshot 2025-06-10 at 3 58 17 PM](https://github.com/user-attachments/assets/ab01edae-4121-42c1-a3c1-3a2c9a3fbbb7)
![Screenshot 2025-06-10 at 3 59 05 PM](https://github.com/user-attachments/assets/1ed7541a-25c4-4a44-acf8-14872c7cb065)
![Screenshot 2025-06-10 at 3 59 19 PM](https://github.com/user-attachments/assets/92472c02-bf7e-470d-a870-7a7215d27d8d)

### What I changed

I've introduced a sanitization function that cleans the voice name before it's used to generate the cache filename.

- It replaces any illegal filename characters (like /,:,?, etc.) with an underscore _.
- It ensures a default name is used if the voice name is empty.

This change ensures that the generated filenames are always valid, which resolves the crashing error and makes integration with these TTS services more robust.
