### PR TITLE
Allow Type override in OpenAI.Responses.TextContent.

### DIFF
--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/TextContent.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/TextContent.cs
@@ -29,9 +29,9 @@ namespace OpenAI.Responses
         }
 
         [Preserve]
-        public TextContent(string text)
+        public TextContent(string text, ResponseContentType type = ResponseContentType.InputText)
         {
-            Type = ResponseContentType.InputText;
+            Type = type;
             Text = text;
         }
 


### PR DESCRIPTION
[Assistant messages must now be type output_text instead of input_text](https://community.openai.com/t/input-text-field-removed-from-response-api/1363365/8)

Adding this overload allows the user to do 
```C#
new Message(OpenAI.Role.Assistant, new OpenAI.Responses.TextContent(message, ResponseContentType.OutputText));
```

in order to create an assistant message.