### PR TITLE
com.openai.unity 8.8.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ obj/
 *.suo
 /*.sln
 *.sln
+/*.slnx
+*.slnx
 *.user
 *.unityproj
 *.ipch

--- a/OpenAI/.editorconfig
+++ b/OpenAI/.editorconfig
@@ -22,7 +22,7 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_open_brace = all
 
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:error
+dotnet_style_require_accessibility_modifiers = error
 
 # Code-block preferences
 csharp_prefer_braces = true:error
@@ -33,8 +33,8 @@ dotnet_style_predefined_type_for_locals_parameters_members = true
 
 # Code Style
 csharp_style_var_when_type_is_apparent = true
-
 dotnet_sort_system_directives_first = false
+dotnet_analyzer_diagnostic.category-Style.severity = none
 
 #### Resharper/Rider Rules ####
 # https://www.jetbrains.com/help/resharper/EditorConfig_Properties.html

--- a/OpenAI/Packages/com.openai.unity/Runtime/Audio/SpeechClip.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Audio/SpeechClip.cs
@@ -12,6 +12,9 @@ namespace OpenAI.Audio
     public sealed class SpeechClip : IDisposable
     {
         [Preserve]
+        private SpeechClip() { }
+
+        [Preserve]
         internal SpeechClip(string name, string cachePath, AudioClip audioClip)
         {
             Name = name;
@@ -30,7 +33,8 @@ namespace OpenAI.Audio
             SampleRate = sampleRate;
         }
 
-        ~SpeechClip() => Dispose();
+        [Preserve]
+        ~SpeechClip() => Dispose(false);
 
         [Preserve]
         public string Name { get; }
@@ -113,12 +117,22 @@ namespace OpenAI.Audio
         public static implicit operator string(SpeechClip clip) => clip?.CachePath;
 
         [Preserve]
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                audioSamples?.Dispose();
+                audioSamples = null;
+                audioData?.Dispose();
+                audioData = null;
+            }
+        }
+
+        [Preserve]
         public void Dispose()
         {
-            audioSamples?.Dispose();
-            audioSamples = null;
-            audioData?.Dispose();
-            audioData = null;
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Chat/AudioOutput.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Chat/AudioOutput.cs
@@ -137,7 +137,9 @@ namespace OpenAI.Chat
             if (disposing)
             {
                 audioSamples?.Dispose();
-                AudioData.Dispose();
+                audioSamples = null;
+                audioData?.Dispose();
+                audioData = null;
             }
         }
 

--- a/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
@@ -9,7 +9,6 @@ using OpenAI.Images;
 using Utilities.Async;
 using System;
 
-
 #if !PLATFORM_WEBGL
 using System.IO;
 using Utilities.WebRequestRest;
@@ -19,7 +18,7 @@ namespace OpenAI.Extensions
 {
     public static class TextureExtensions
     {
-        internal static async Task<(Texture2D, string)> ConvertFromBase64Async(string b64, bool debug = false, CancellationToken cancellationToken = default)
+        internal static async Task<(Texture2D, string)> ConvertFromBase64Async(string b64, bool debug, CancellationToken cancellationToken)
         {
             using var imageData = NativeArrayExtensions.FromBase64String(b64, Allocator.Persistent);
 #if PLATFORM_WEBGL

--- a/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
@@ -77,7 +77,7 @@ namespace OpenAI.Extensions
                     else if (!string.IsNullOrWhiteSpace(imageResult.Url))
                     {
                         texture = await Rest.DownloadTextureAsync(imageResult.Url, parameters: new RestParameters(debug: debug), cancellationToken: cancellationToken);
-                        cachedPath = Rest.TryGetDownloadCacheItem(imageResult.Url, out var path) ? new Uri(path) : null;
+                        cachedPath = Rest.TryGetDownloadCacheItem(new Uri(imageResult.Url), out var path) ? path : null;
                     }
                     else
                     {

--- a/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
@@ -1,27 +1,40 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Unity.Collections;
 using UnityEngine;
+using Utilities.Extensions;
+using OpenAI.Images;
+using Utilities.Async;
+using System;
+
+
+#if !PLATFORM_WEBGL
+using System.IO;
 using Utilities.WebRequestRest;
+#endif
 
 namespace OpenAI.Extensions
 {
-    internal static class TextureExtensions
+    public static class TextureExtensions
     {
-        public static async Task<(Texture2D, string)> ConvertFromBase64Async(string b64, bool debug, CancellationToken cancellationToken)
+        internal static async Task<(Texture2D, string)> ConvertFromBase64Async(string b64, bool debug = false, CancellationToken cancellationToken = default)
         {
-            var imageData = Convert.FromBase64String(b64);
+            using var imageData = NativeArrayExtensions.FromBase64String(b64, Allocator.Persistent);
 #if PLATFORM_WEBGL
             var texture = new Texture2D(2, 2);
+#if UNITY_6000_0_OR_NEWER
             texture.LoadImage(imageData);
+#else
+            texture.LoadImage(imageData.ToArray());
+#endif
             return await Task.FromResult((texture, string.Empty));
 #else
             if (!Rest.TryGetDownloadCacheItem(b64, out var localFilePath))
             {
-                await File.WriteAllBytesAsync(localFilePath, imageData, cancellationToken).ConfigureAwait(true);
+                await using var fs = new FileStream(localFilePath, FileMode.Create, FileAccess.Write);
+                await fs.WriteAsync(imageData, cancellationToken: cancellationToken);
                 localFilePath = $"file://{localFilePath}";
             }
 
@@ -29,6 +42,55 @@ namespace OpenAI.Extensions
             Rest.TryGetDownloadCacheItem(b64, out var cachedPath);
             return (texture, cachedPath);
 #endif
+        }
+
+        /// <summary>
+        /// Loads a Texture2D from an ImageResult, handling base64, cached path, or URL.
+        /// </summary>
+        /// <param name="imageResult">The <see cref="ImageResult"/> to load the texture for.</param>
+        /// <param name="debug">Optional, debug flag.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns>
+        /// A tuple containing the converted <see cref="Texture2D"/> and the cached file path as a string.
+        /// </returns>
+        public static async Task<(Texture2D, Uri)> LoadTextureAsync(this ImageResult imageResult, bool debug = false, CancellationToken cancellationToken = default)
+        {
+            await Awaiters.UnityMainThread;
+
+            if (imageResult.Texture.IsNull())
+            {
+                if (!string.IsNullOrWhiteSpace(imageResult.B64_Json))
+                {
+                    var (texture, cachedPath) = await ConvertFromBase64Async(imageResult.B64_Json, debug, cancellationToken);
+                    imageResult.Texture = texture;
+                    imageResult.CachedPathUri = new Uri(cachedPath);
+                }
+                else
+                {
+                    Texture2D texture;
+                    Uri cachedPath;
+
+                    if (imageResult.CachedPathUri != null)
+                    {
+                        texture = await Rest.DownloadTextureAsync(imageResult.CachedPathUri, parameters: new RestParameters(debug: debug), cancellationToken: cancellationToken);
+                        cachedPath = imageResult.CachedPathUri;
+                    }
+                    else if (!string.IsNullOrWhiteSpace(imageResult.Url))
+                    {
+                        texture = await Rest.DownloadTextureAsync(imageResult.Url, parameters: new RestParameters(debug: debug), cancellationToken: cancellationToken);
+                        cachedPath = Rest.TryGetDownloadCacheItem(imageResult.Url, out var path) ? new Uri(path) : null;
+                    }
+                    else
+                    {
+                        throw new System.Exception("ImageResult does not contain valid image data.");
+                    }
+
+                    imageResult.Texture = texture;
+                    imageResult.CachedPathUri = cachedPath;
+                }
+            }
+
+            return (imageResult.Texture, imageResult.CachedPathUri);
         }
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
@@ -30,22 +30,14 @@ namespace OpenAI.Extensions
 #endif // UNITY_6000_0_OR_NEWER
             return await Task.FromResult((texture, null as Uri));
 #else
-            if (!Rest.TryGetDownloadCacheItem(b64, out var localFilePath))
+            if (!Rest.TryGetDownloadCacheItem(b64, out Uri localUri))
             {
-                await using var fs = new FileStream(localFilePath, FileMode.Create, FileAccess.Write);
+                await using var fs = new FileStream(localUri.LocalPath, FileMode.Create, FileAccess.Write);
                 await fs.WriteAsync(imageData, cancellationToken: cancellationToken);
-                localFilePath = $"file://{localFilePath}";
             }
 
-            var texture = await Rest.DownloadTextureAsync(localFilePath, parameters: new RestParameters(debug: debug), cancellationToken: cancellationToken);
-            Rest.TryGetDownloadCacheItem(b64, out var cachedPath);
-            Uri cachedUri = null;
-
-            if (!string.IsNullOrWhiteSpace(cachedPath))
-            {
-                cachedUri = new Uri(cachedPath);
-            }
-
+            var texture = await Rest.DownloadTextureAsync(localUri.LocalPath, parameters: new RestParameters(debug: debug), cancellationToken: cancellationToken);
+            Rest.TryGetDownloadCacheItem(b64, out Uri cachedUri);
             return (texture, cachedUri);
 #endif // !PLATFORM_WEBGL
         }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Extensions/TextureExtensions.cs
@@ -57,7 +57,7 @@ namespace OpenAI.Extensions
         /// <param name="debug">Optional, debug flag.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>
-        /// A tuple containing the converted <see cref="Texture2D"/> and the cached file path as a string.
+        /// A tuple containing the converted <see cref="Texture2D"/> and the cached file path as a <see cref="Uri"/>.
         /// </returns>
         public static async Task<(Texture2D, Uri)> LoadTextureAsync(this ImageResult imageResult, bool debug = false, CancellationToken cancellationToken = default)
         {
@@ -88,7 +88,7 @@ namespace OpenAI.Extensions
                     }
                     else
                     {
-                        throw new Exception("ImageResult does not contain valid image data.");
+                        throw new InvalidOperationException("ImageResult does not contain valid image data.");
                     }
 
                     imageResult.Texture = texture;

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageResult.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageResult.cs
@@ -18,6 +18,12 @@ namespace OpenAI.Images
             [JsonProperty("revised_prompt")] string revisedPrompt)
         {
             Url = url;
+
+            if (!string.IsNullOrWhiteSpace(url))
+            {
+                Uri = new Uri(url);
+            }
+
             B64_Json = b64_json;
             RevisedPrompt = revisedPrompt;
         }
@@ -25,6 +31,10 @@ namespace OpenAI.Images
         [Preserve]
         [JsonProperty("url", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Url { get; private set; }
+
+        [Preserve]
+        [JsonIgnore]
+        public Uri Uri { get; }
 
         [Preserve]
         [JsonProperty("b64_json", DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageResult.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImageResult.cs
@@ -56,7 +56,12 @@ namespace OpenAI.Images
 
         [Preserve]
         [JsonIgnore]
-        public string CachedPath { get; internal set; }
+        [Obsolete("use CachedPathUri")]
+        public string CachedPath => CachedPathUri?.ToString();
+
+        [Preserve]
+        [JsonIgnore]
+        public Uri CachedPathUri { get; internal set; }
 
         [Preserve]
         [JsonIgnore]
@@ -75,9 +80,9 @@ namespace OpenAI.Images
         [Preserve]
         public override string ToString()
         {
-            if (!string.IsNullOrWhiteSpace(CachedPath))
+            if (CachedPathUri != null)
             {
-                return CachedPath;
+                return CachedPathUri.ToString();
             }
 
             if (!string.IsNullOrWhiteSpace(B64_Json))

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
-using Utilities.Async;
 using Utilities.WebRequestRest;
 
 namespace OpenAI.Images

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
@@ -181,12 +181,10 @@ namespace OpenAI.Images
 
             await Rest.ValidateCacheDirectoryAsync();
 
-            var downloads = imagesResponse.Results.Select(DownloadAsync).ToList();
-
             Task<(Texture2D, Uri)> DownloadAsync(ImageResult result)
                 => result.LoadTextureAsync(debug: EnableDebug, cancellationToken);
 
-            await Task.WhenAll(downloads).ConfigureAwait(true);
+            await Task.WhenAll(imagesResponse.Results.Select(DownloadAsync).ToList()).ConfigureAwait(true);
 
             for (var i = 0; i < imagesResponse.Results.Count; i++)
             {

--- a/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Images/ImagesEndpoint.cs
@@ -180,33 +180,17 @@ namespace OpenAI.Images
             }
 
             await Rest.ValidateCacheDirectoryAsync();
+
             var downloads = imagesResponse.Results.Select(DownloadAsync).ToList();
 
-            async Task DownloadAsync(ImageResult result)
-            {
-                await Awaiters.UnityMainThread;
-
-                if (string.IsNullOrWhiteSpace(result.Url))
-                {
-                    var (texture, cachePath) = await TextureExtensions.ConvertFromBase64Async(result.B64_Json, EnableDebug, cancellationToken);
-                    result.Texture = texture;
-                    result.CachedPath = cachePath;
-                }
-                else
-                {
-                    result.Texture = await Rest.DownloadTextureAsync(result.Url, parameters: new RestParameters(debug: EnableDebug), cancellationToken: cancellationToken);
-
-                    if (Rest.TryGetDownloadCacheItem(result.Url, out var cachedPath))
-                    {
-                        result.CachedPath = cachedPath;
-                    }
-                }
-            }
+            Task<(Texture2D, Uri)> DownloadAsync(ImageResult result)
+                => result.LoadTextureAsync(debug: EnableDebug, cancellationToken);
 
             await Task.WhenAll(downloads).ConfigureAwait(true);
 
-            foreach (var result in imagesResponse.Results)
+            for (var i = 0; i < imagesResponse.Results.Count; i++)
             {
+                var result = imagesResponse.Results[i];
                 result.CreatedAt = DateTimeOffset.FromUnixTimeSeconds(imagesResponse.CreatedAtUnixSeconds).UtcDateTime;
                 result.Background = imagesResponse.Background;
                 result.OutputFormat = imagesResponse.OutputFormat;

--- a/OpenAI/Packages/com.openai.unity/Runtime/Models/Model.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Models/Model.cs
@@ -549,7 +549,7 @@ namespace OpenAI.Models
         #region Specialized Models
 
         /// <summary>
-        /// GPT‑5.1-Codex-Max is purpose-built for agentic coding.
+        /// GPT-5.1-Codex-Max is purpose-built for agentic coding.
         /// It's only available in the Responses API.
         /// </summary>
         /// <remarks>

--- a/OpenAI/Packages/com.openai.unity/Runtime/Models/Model.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Models/Model.cs
@@ -105,6 +105,18 @@ namespace OpenAI.Models
         #region Reasoning Models
 
         /// <summary>
+        /// GPT-5.2 pro is available in the Responses API only to enable support for multi-turn model interactions before responding to API requests,
+        /// and other advanced API features in the future. Since GPT-5.2 pro is designed to tackle tough problems,
+        /// some requests may take several minutes to finish. To avoid timeouts, try using background mode.
+        /// GPT-5.2 pro supports reasoning.effort: medium, high, xhigh.
+        /// </summary>
+        /// <remarks>
+        /// - Context Window: 400,000 context window<br/>
+        /// - Max Output Tokens: 128,000 max output tokens
+        /// </remarks>
+        public static Model GPT5_2_Pro { get; } = new("gpt-5.2-pro", "openai");
+
+        /// <summary>
         /// The o1 series of models are trained with reinforcement learning to perform complex reasoning.
         /// o1 models think before they answer, producing a long internal chain of thought before responding to the user.
         /// </summary>
@@ -217,6 +229,15 @@ namespace OpenAI.Models
         #endregion Realtime Models
 
         #region Chat Models
+
+        /// <summary>
+        /// GPT-5.2 is our flagship model for coding and agentic tasks across industries. 
+        /// </summary>
+        /// <remarks>
+        /// - Context Window: 400,000 context window<br/>
+        /// - Max Output Tokens: 128,000 max output tokens
+        /// </remarks>
+        public static Model GPT5_2 { get; } = new("gpt-5.2", "openai");
 
         /// <summary>
         /// GPT-5 is our flagship model for coding, reasoning, and agentic tasks across domains.
@@ -526,6 +547,35 @@ namespace OpenAI.Models
         #endregion Image Models
 
         #region Specialized Models
+
+        /// <summary>
+        /// GPT‑5.1-Codex-Max is purpose-built for agentic coding.
+        /// It's only available in the Responses API.
+        /// </summary>
+        /// <remarks>
+        /// - Context Window: 400,000 tokens<br/>
+        /// - Max Output Tokens: 128,000 tokens
+        /// </remarks>
+        public static Model GPT5_1_CodexMax { get; } = new("gpt-5.1-codex-max", "openai");
+
+        /// <summary>
+        /// GPT-5.1-Codex is a version of GPT-5 optimized for agentic coding tasks in Codex or similar environments.
+        /// It's available in the Responses API
+        /// </summary>
+        /// <remarks>
+        /// - Context Window: 400,000 tokens<br/>
+        /// - Max Output Tokens: 128,000 tokens
+        /// </remarks>
+        public static Model GPT5_1_Codex { get; } = new("gpt-5.1-codex", "openai");
+
+        /// <summary>
+        /// GPT-5.1 Codex mini is a smaller, more cost-effective, less-capable version of GPT-5.1-Codex.
+        /// </summary>
+        /// <remarks>
+        /// - Context Window: 400,000 tokens<br/>
+        /// - Max Output Tokens: 128,000 tokens
+        /// </remarks>
+        public static Model GPT5_1_CodexMini { get; } = new("gpt-5.1-codex-mini", "openai");
 
         /// <summary>
         /// GPT-5-Codex is a version of GPT-5 optimized for agentic coding tasks in Codex or similar environments.

--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/CreateResponseRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/CreateResponseRequest.cs
@@ -164,7 +164,7 @@ namespace OpenAI.Responses
         {
             Input = input?.ToArray() ?? throw new ArgumentNullException(nameof(input));
             Model = string.IsNullOrWhiteSpace(model?.Id) && prompt == null
-                ? Models.Model.GPT4oRealtime
+                ? Models.Model.GPT5_Mini
                 : model;
             Background = background;
             Include = include?.ToList();

--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/MCPApprovalRequest.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/MCPApprovalRequest.cs
@@ -34,6 +34,7 @@ namespace OpenAI.Responses
             Name = name;
             Arguments = arguments;
             ServerLabel = serverLabel;
+            Type = ResponseItemType.McpApprovalRequest;
         }
 
         /// <inheritdoc />

--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/MCPApprovalResponse.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/MCPApprovalResponse.cs
@@ -28,6 +28,14 @@ namespace OpenAI.Responses
             Reason = reason;
         }
 
+        [Preserve]
+        public MCPApprovalResponse(string approvalRequestId, bool approve)
+        {
+            ApprovalRequestId = approvalRequestId;
+            Approve = approve;
+            Type = ResponseItemType.McpApprovalResponse;
+        }
+
         /// <inheritdoc />
         [Preserve]
         [JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/MCPToolCall.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/MCPToolCall.cs
@@ -127,6 +127,6 @@ namespace OpenAI.Responses
         /// </summary>
         [Preserve]
         [JsonProperty("error", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string Error { get; }
+        public JObject Error { get; }
     }
 }

--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/Message.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/Message.cs
@@ -41,7 +41,7 @@ namespace OpenAI.Responses
 
         [Preserve]
         public Message(Role role, string text)
-            : this(role, new TextContent(text))
+            : this(role, new TextContent(text, role == Role.Assistant ? ResponseContentType.OutputText : ResponseContentType.InputText))
         {
         }
 

--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/ResponsesEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/ResponsesEndpoint.cs
@@ -409,7 +409,8 @@ namespace OpenAI.Responses
                         }
                         case "error":
                         {
-                            serverSentEvent = sseResponse.Deserialize<Error>(client);
+                            var error = @object["error"]?.ToObject<Error>();
+                            serverSentEvent = error ?? sseResponse.Deserialize<Error>(client);
                             break;
                         }
                         // Event status messages with no data payloads:

--- a/OpenAI/Packages/com.openai.unity/Runtime/Responses/TextContent.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Responses/TextContent.cs
@@ -29,9 +29,9 @@ namespace OpenAI.Responses
         }
 
         [Preserve]
-        public TextContent(string text)
+        public TextContent(string text, ResponseContentType type = ResponseContentType.InputText)
         {
-            Type = ResponseContentType.InputText;
+            Type = type;
             Text = text;
         }
 

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadsEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadsEndpoint.cs
@@ -507,6 +507,7 @@ namespace OpenAI.Threads
             {
                 IServerSentEvent serverSentEvent = null;
                 var @event = ssEvent.Value.Value<string>();
+                var @object = ssEvent.Data ?? ssEvent.Value;
 
                 // ReSharper disable AccessToModifiedClosure
                 try
@@ -580,6 +581,7 @@ namespace OpenAI.Threads
                             serverSentEvent = message;
                             break;
                         case "error":
+                            var error = @object["error"]?.ToObject<Error>();
                             serverSentEvent = sseResponse.Deserialize<Error>(client);
                             break;
                         default:

--- a/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadsEndpoint.cs
+++ b/OpenAI/Packages/com.openai.unity/Runtime/Threads/ThreadsEndpoint.cs
@@ -582,7 +582,7 @@ namespace OpenAI.Threads
                             break;
                         case "error":
                             var error = @object["error"]?.ToObject<Error>();
-                            serverSentEvent = sseResponse.Deserialize<Error>(client);
+                            serverSentEvent = error ?? sseResponse.Deserialize<Error>(client);
                             break;
                         default:
                             // if not properly handled raise it up to caller to deal with it themselves.

--- a/OpenAI/Packages/com.openai.unity/Samples~/Assistant/AssistantBehaviour.cs
+++ b/OpenAI/Packages/com.openai.unity/Samples~/Assistant/AssistantBehaviour.cs
@@ -342,9 +342,8 @@ namespace OpenAI.Samples.Assistant
                 var stopwatch = Stopwatch.StartNew();
                 using var speechClip = await openAI.AudioEndpoint.GetSpeechAsync(
                     request,
-                    partialClip => streamAudioSource.SampleCallbackAsync(partialClip.AudioSamples),
-                    cancellationToken)
-                    .ConfigureAwait(true);
+                    async partialClip => await streamAudioSource.SampleCallbackAsync(partialClip.AudioSamples),
+                    cancellationToken).ConfigureAwait(true);
                 var playbackTime = speechClip.Length - (float)stopwatch.Elapsed.TotalSeconds + 0.1f;
 
                 if (playbackTime > 0)

--- a/OpenAI/Packages/com.openai.unity/Samples~/Chat/ChatBehaviour.cs
+++ b/OpenAI/Packages/com.openai.unity/Samples~/Chat/ChatBehaviour.cs
@@ -11,7 +11,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using TMPro;
-using Unity.Collections;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;

--- a/OpenAI/Packages/com.openai.unity/Samples~/Chat/ChatBehaviour.cs
+++ b/OpenAI/Packages/com.openai.unity/Samples~/Chat/ChatBehaviour.cs
@@ -248,7 +248,7 @@ namespace OpenAI.Samples.Chat
             var stopwatch = Stopwatch.StartNew();
             using var speechClip = await openAI.AudioEndpoint.GetSpeechAsync(
                 request,
-                partialClip => streamAudioSource.SampleCallbackAsync(partialClip.AudioSamples),
+                async partialClip => await streamAudioSource.SampleCallbackAsync(partialClip.AudioSamples),
                 cancellationToken)
                 .ConfigureAwait(true);
             var playbackTime = speechClip.Length - (float)stopwatch.Elapsed.TotalSeconds + 0.1f;

--- a/OpenAI/Packages/com.openai.unity/Samples~/Responses/ResponsesBehaviour.cs
+++ b/OpenAI/Packages/com.openai.unity/Samples~/Responses/ResponsesBehaviour.cs
@@ -193,7 +193,7 @@ namespace OpenAI.Samples.Responses
                 var stopwatch = Stopwatch.StartNew();
                 using var speechClip = await openAI.AudioEndpoint.GetSpeechAsync(
                     request,
-                    partialClip => streamAudioSource.SampleCallbackAsync(partialClip.AudioSamples),
+                    async partialClip => await streamAudioSource.SampleCallbackAsync(partialClip.AudioSamples),
                     cancellationToken)
                     .ConfigureAwait(true);
                 var playbackTime = speechClip.Length - (float)stopwatch.Elapsed.TotalSeconds + 0.1f;

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
-using OpenAI.Extensions;
 
 namespace OpenAI.Tests
 {

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
@@ -224,7 +224,7 @@ namespace OpenAI.Tests
                 {
                     Debug.Log(result.ToString());
                     Assert.IsNotNull(result.Texture);
-                    Assert.IsNotNull(result.CachedPathUri);
+                    Assert.IsNull(result.CachedPathUri);
                 }
             }
             catch (Exception e)
@@ -252,7 +252,7 @@ namespace OpenAI.Tests
                 {
                     Debug.Log(result.ToString());
                     Assert.IsNotNull(result.Texture);
-                    Assert.IsNotNull(result.CachedPathUri);
+                    Assert.IsNull(result.CachedPathUri);
                 }
             }
             catch (Exception e)

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_05_Images.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
+using OpenAI.Extensions;
 
 namespace OpenAI.Tests
 {
@@ -44,12 +45,10 @@ namespace OpenAI.Tests
                     var result = imageResults[i];
                     Assert.IsNotNull(result);
                     Assert.IsNotNull(result.Texture);
+                    Assert.IsNotNull(result.CachedPathUri);
                     Assert.IsFalse(string.IsNullOrWhiteSpace(result.B64_Json));
-                    var imageBytes = Convert.FromBase64String(result.B64_Json);
-                    Assert.IsNotNull(imageBytes);
                     var path = Path.Combine(testDirectory, $"{nameof(Test_01_01_GenerateImages)}-{i}-{DateTime.UtcNow:yyyyMMddHHmmss}.jpeg");
-                    await using var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
-                    await fileStream.WriteAsync(imageBytes, 0, imageBytes.Length);
+                    File.Copy(result.CachedPathUri.LocalPath, path, true);
                 }
             }
             catch (Exception e)
@@ -82,12 +81,9 @@ namespace OpenAI.Tests
                     var result = imageResults[i];
                     Assert.IsNotNull(result);
                     Assert.IsNotNull(result.Texture);
-                    Assert.IsFalse(string.IsNullOrWhiteSpace(result.B64_Json));
-                    var imageBytes = Convert.FromBase64String(result.B64_Json);
-                    Assert.IsNotNull(imageBytes);
+                    Assert.IsNotNull(result.CachedPathUri);
                     var path = Path.Combine(testDirectory, $"{nameof(Test_02_01_CreateImageEdit_Path)}-{i}-{DateTime.UtcNow:yyyyMMddHHmmss}.png");
-                    await using var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
-                    await fileStream.WriteAsync(imageBytes, 0, imageBytes.Length);
+                    File.Copy(result.CachedPathUri.LocalPath, path, true);
                 }
             }
             catch (Exception e)
@@ -122,12 +118,10 @@ namespace OpenAI.Tests
                     var result = imageResults[i];
                     Assert.IsNotNull(result);
                     Assert.IsNotNull(result.Texture);
+                    Assert.IsNotNull(result.CachedPathUri);
                     Assert.IsFalse(string.IsNullOrWhiteSpace(result.B64_Json));
-                    var imageBytes = Convert.FromBase64String(result.B64_Json);
-                    Assert.IsNotNull(imageBytes);
                     var path = Path.Combine(testDirectory, $"{nameof(Test_02_02_CreateImageEdit_Texture)}-{i}-{DateTime.UtcNow:yyyyMMddHHmmss}.png");
-                    await using var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
-                    await fileStream.WriteAsync(imageBytes, 0, imageBytes.Length);
+                    File.Copy(result.CachedPathUri.LocalPath, path, true);
                 }
             }
             catch (Exception e)
@@ -159,12 +153,10 @@ namespace OpenAI.Tests
                     var result = imageResults[i];
                     Assert.IsNotNull(result);
                     Assert.IsNotNull(result.Texture);
+                    Assert.IsNotNull(result.CachedPathUri);
                     Assert.IsFalse(string.IsNullOrWhiteSpace(result.B64_Json));
-                    var imageBytes = Convert.FromBase64String(result.B64_Json);
-                    Assert.IsNotNull(imageBytes);
                     var path = Path.Combine(testDirectory, $"{nameof(Test_02_03_CreateImageEdit_MaskAsTransparency)}-{i}-{DateTime.UtcNow:yyyyMMddHHmmss}.png");
-                    await using var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
-                    await fileStream.WriteAsync(imageBytes, 0, imageBytes.Length);
+                    File.Copy(result.CachedPathUri.LocalPath, path, true);
                 }
             }
             catch (Exception e)
@@ -202,12 +194,10 @@ namespace OpenAI.Tests
                     var result = imageResults[i];
                     Assert.IsNotNull(result);
                     Assert.IsNotNull(result.Texture);
+                    Assert.IsNotNull(result.CachedPathUri);
                     Assert.IsFalse(string.IsNullOrWhiteSpace(result.B64_Json));
-                    var imageBytes = Convert.FromBase64String(result.B64_Json);
-                    Assert.IsNotNull(imageBytes);
                     var path = Path.Combine(testDirectory, $"{nameof(Test_02_04_CreateImageEdit_MultipleFiles)}-{i}-{DateTime.UtcNow:yyyyMMddHHmmss}.png");
-                    await using var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
-                    await fileStream.WriteAsync(imageBytes, 0, imageBytes.Length);
+                    File.Copy(result.CachedPathUri.LocalPath, path, true);
                 }
             }
             catch (Exception e)
@@ -232,8 +222,9 @@ namespace OpenAI.Tests
 
                 foreach (var result in imageResults)
                 {
-                    Assert.IsNotNull(result.Texture);
                     Debug.Log(result.ToString());
+                    Assert.IsNotNull(result.Texture);
+                    Assert.IsNotNull(result.CachedPathUri);
                 }
             }
             catch (Exception e)
@@ -261,6 +252,7 @@ namespace OpenAI.Tests
                 {
                     Debug.Log(result.ToString());
                     Assert.IsNotNull(result.Texture);
+                    Assert.IsNotNull(result.CachedPathUri);
                 }
             }
             catch (Exception e)
@@ -289,12 +281,10 @@ namespace OpenAI.Tests
                     var result = imageResults[i];
                     Assert.IsNotNull(result);
                     Assert.IsNotNull(result.Texture);
+                    Assert.IsNotNull(result.CachedPathUri);
                     Assert.IsFalse(string.IsNullOrWhiteSpace(result.B64_Json));
-                    var imageBytes = Convert.FromBase64String(result.B64_Json);
-                    Assert.IsNotNull(imageBytes);
                     var path = Path.Combine(testDirectory, $"{nameof(Test_03_03_CreateImageVariation_Texture_B64_Json)}-{i}-{DateTime.UtcNow:yyyyMMddHHmmss}.png");
-                    await using var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
-                    await fileStream.WriteAsync(imageBytes, 0, imageBytes.Length);
+                    File.Copy(result.CachedPathUri.LocalPath, path, true);
                 }
             }
             catch (Exception e)

--- a/OpenAI/Packages/com.openai.unity/Tests/TestFixture_07_Audio.cs
+++ b/OpenAI/Packages/com.openai.unity/Tests/TestFixture_07_Audio.cs
@@ -182,10 +182,10 @@ namespace OpenAI.Tests
                 input: "Hello world!",
                 responseFormat: SpeechResponseFormat.PCM);
             var clipQueue = new ConcurrentQueue<AudioClip>();
-            using var speechClip = await OpenAIClient.AudioEndpoint.GetSpeechAsync(request, partialClip =>
+            using var speechClip = await OpenAIClient.AudioEndpoint.GetSpeechAsync(request, async partialClip =>
             {
                 clipQueue.Enqueue(partialClip);
-                return Task.CompletedTask;
+                await Task.CompletedTask;
             });
             Debug.Log(speechClip.CachePath);
             Assert.IsNotEmpty(speechClip.AudioSamples);
@@ -205,10 +205,10 @@ namespace OpenAI.Tests
                 responseFormat: SpeechResponseFormat.PCM,
                 instructions: instructions);
             var clipQueue = new ConcurrentQueue<AudioClip>();
-            using var speechClip = await OpenAIClient.AudioEndpoint.GetSpeechAsync(request, partialClip =>
+            using var speechClip = await OpenAIClient.AudioEndpoint.GetSpeechAsync(request, async partialClip =>
             {
                 clipQueue.Enqueue(partialClip);
-                return Task.CompletedTask;
+                await Task.CompletedTask;
             });
             Debug.Log(speechClip.CachePath);
             Assert.IsNotEmpty(speechClip.AudioSamples);

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -17,8 +17,9 @@
     "url": "https://github.com/StephenHodgson"
   },
   "dependencies": {
+    "com.utilities.audio": "3.0.2",
     "com.utilities.encoder.wav": "3.0.2",
-    "com.utilities.rest": "5.1.0",
+    "com.utilities.rest": "5.1.1",
     "com.utilities.websockets": "2.0.0"
   },
   "samples": [

--- a/OpenAI/Packages/com.openai.unity/package.json
+++ b/OpenAI/Packages/com.openai.unity/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenAI",
   "description": "A OpenAI package for the Unity to use though their RESTful API.\n\nIndependently developed, this is not an official library and I am not affiliated with OpenAI.\n\nAn OpenAI API account is required.",
   "keywords": [],
-  "version": "8.8.7",
+  "version": "8.8.8",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.openai.unity#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.openai.unity/releases",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "com.utilities.encoder.wav": "3.0.2",
-    "com.utilities.rest": "5.0.4",
+    "com.utilities.rest": "5.1.0",
     "com.utilities.websockets": "2.0.0"
   },
   "samples": [

--- a/OpenAI/Packages/manifest.json
+++ b/OpenAI/Packages/manifest.json
@@ -3,6 +3,7 @@
     "com.unity.ide.rider": "3.0.38",
     "com.unity.ide.visualstudio": "2.0.25",
     "com.unity.inputsystem": "1.14.2",
+    "com.unity.mobile.android-logcat": "1.4.6",
     "com.unity.textmeshpro": "3.0.9",
     "com.unity.ugui": "1.0.0",
     "com.utilities.buildpipeline": "1.8.1"

--- a/OpenAI/ProjectSettings/ProjectSettings.asset
+++ b/OpenAI/ProjectSettings/ProjectSettings.asset
@@ -998,7 +998,7 @@ PlayerSettings:
     m_VersionCode: 1
     m_VersionName: 8.7.4
   apiCompatibilityLevel: 3
-  activeInputHandler: 2
+  activeInputHandler: 1
   windowsGamepadBackendHint: 0
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
- Optimize image texture loading
- Allow setting `Responses.TextContent.Type` to `OutputText` for `Role.Assistant` messages by @TypeDefinition
- Fix free-after-use crash with audio refactor
- Fixed wrapped server sent event error object
- Fixed ability to create MCPApprovalResponse for mcp tool approvals
- Fixed MCPToolCall.Error deserialization
- Updated default models
- com.utilities.rest -> 5.1.1
- com.utilities.audio -> 3.0.2